### PR TITLE
Fix: Allow header shapes with non-zero alpha in importer

### DIFF
--- a/tests/test_importer.py
+++ b/tests/test_importer.py
@@ -31,6 +31,13 @@ class TestImporter(unittest.TestCase):
         }
         self.assertTrue(fh6_importer.is_header_shape(valid_header))
 
+        valid_header_no_alpha = {
+            "type": 1,
+            "data": [0.0, 0.0, 100, 100],
+            "color": [255, 255, 255, 255],
+        }
+        self.assertTrue(fh6_importer.is_header_shape(valid_header_no_alpha))
+
         invalid_type = valid_header.copy()
         invalid_type["type"] = 2
         self.assertFalse(fh6_importer.is_header_shape(invalid_type))

--- a/tools/fh6_import_layer_table.py
+++ b/tools/fh6_import_layer_table.py
@@ -794,7 +794,6 @@ def is_header_shape(s):
         and abs(s["data"][0]) < 0.0001
         and abs(s["data"][1]) < 0.0001
         and len(s["color"]) >= 4
-        and s["color"][3] == 0
     )
 
 


### PR DESCRIPTION
This PR fixes the issue where generated liveries are sometimes pushed to the bottom right corner in Forza Horizon 6. It correctly identifies canvas header shapes regardless of their alpha value.

---
*PR created automatically by Jules for task [5328987560199829633](https://jules.google.com/task/5328987560199829633) started by @eddie772tw*