### PR TITLE
feat: implement early convergence and dual QoL optimizations 

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,29 @@ Support both CPU and GPU JIT acceleration, provide GUI & smooth import expierenc
 
 ---
 
+## 開發者規範與程式碼格式化 / Developer Guide & Formatting
+
+專案採用 **[Ruff](https://github.com/astral-sh/ruff)** 作為標準的程式碼格式化與風格檢查工具。為確保代碼風格一致，並能順利通過 GitHub Actions 的 CI 檢查，請在提交代碼前遵循以下程序進行格式化：
+
+*   **全量格式化代碼 / Reformat All Code**：
+    ```bash
+    # 在虛擬環境外 / Outside venv
+    ruff format .
+
+    # 在 Windows 虛擬環境內 / Inside Windows venv
+    .venv\Scripts\ruff.exe format .
+    ```
+*   **驗證排版格式 / Verify Code Formatting**：
+    ```bash
+    # 在虛擬環境外 / Outside venv
+    ruff format --check .
+
+    # 在 Windows 虛擬環境內 / Inside Windows venv
+    .venv\Scripts\ruff.exe format --check .
+    ```
+
+---
+
 ## 開源授權與致謝 / License & Credits
 
 *   **MIT License**：Copyright (c) 2026 罐頭 (eddie772tw) & 貢獻者。

--- a/evaluators/numba_evaluator.py
+++ b/evaluators/numba_evaluator.py
@@ -281,25 +281,31 @@ class NumbaEvaluator(BaseEvaluator):
                 )
             return optimized_shapes
         else:
-            final_shapes = []
-            reset_count = 0
-            final_shapes.append(shapes_list[0])
+            center_x = float(width) / 2.0
+            center_y = float(height) / 2.0
+
+            valid_shapes = []
+            discarded_shapes = []
+
             for i in range(1, num_shapes):
                 s = shapes_list[i]
                 if visible_mask[i]:
-                    final_shapes.append(s)
+                    valid_shapes.append(s)
                 else:
                     reset_shape = {
                         "type": 32,
-                        "data": [-1000.0, -1000.0, 0.01, 0.01, 0.0],
+                        "data": [center_x, center_y, 0.01, 0.01, 0.0],
                         "color": [0, 0, 0, 255],
                         "score": 0.0,
                     }
-                    final_shapes.append(reset_shape)
-                    reset_count += 1
+                    discarded_shapes.append(reset_shape)
+
+            final_shapes = [shapes_list[0]] + valid_shapes + discarded_shapes
+            reset_count = len(discarded_shapes)
+
             if reset_count > 0:
                 print(
-                    f"\n[Optimization] Final check: reset {reset_count} redundant shapes to off-screen microscopic opaque shapes."
+                    f"\n[Optimization] Final check: reset {reset_count} redundant shapes to microscopic opaque shapes at center ({center_x:.1f}, {center_y:.1f}) pushed to top layers."
                 )
             return final_shapes
 

--- a/evaluators/pure_python_evaluator.py
+++ b/evaluators/pure_python_evaluator.py
@@ -589,25 +589,31 @@ class PurePythonEvaluator(BaseEvaluator):
                 )
             return optimized_shapes
         else:
-            final_shapes = []
-            reset_count = 0
-            final_shapes.append(shapes_list[0])
+            center_x = float(width) / 2.0
+            center_y = float(height) / 2.0
+
+            valid_shapes = []
+            discarded_shapes = []
+
             for i in range(1, num_shapes):
                 s = shapes_list[i]
                 if visible_mask[i]:
-                    final_shapes.append(s)
+                    valid_shapes.append(s)
                 else:
                     reset_shape = {
                         "type": 32,
-                        "data": [-1000.0, -1000.0, 0.01, 0.01, 0.0],
+                        "data": [center_x, center_y, 0.01, 0.01, 0.0],
                         "color": [0, 0, 0, 255],
                         "score": 0.0,
                     }
-                    final_shapes.append(reset_shape)
-                    reset_count += 1
+                    discarded_shapes.append(reset_shape)
+
+            final_shapes = [shapes_list[0]] + valid_shapes + discarded_shapes
+            reset_count = len(discarded_shapes)
+
             if reset_count > 0:
                 print(
-                    f"\n[Optimization] Final check: reset {reset_count} redundant shapes to off-screen microscopic opaque shapes."
+                    f"\n[Optimization] Final check: reset {reset_count} redundant shapes to microscopic opaque shapes at center ({center_x:.1f}, {center_y:.1f}) pushed to top layers."
                 )
             return final_shapes
 

--- a/fh6_painter_studio_gui.py
+++ b/fh6_painter_studio_gui.py
@@ -1654,11 +1654,14 @@ class ForzaStudioGUI:
 
         # Confirm user opens ungrouped shapes
         confirm = messagebox.askyesno(
-            "Game Injection Confirmation",
-            "Before injecting, please ensure:\n"
-            "1. Forza Horizon 6 (forzahorizon6.exe) is running.\n"
-            f"2. You are inside the Vinyl Group Editor with a fresh template of exactly {layers} ungrouped circular layers.\n\n"
-            "Would you like to proceed with memory injection?",
+            "遊戲記憶體注入確認 / Game Injection Confirmation",
+            "在開始注入前，請務必確認以下事項：\n\n"
+            "1. 《極限競速：地平線 6》遊戲主程式 (forzahorizon6.exe) 正在運行中。\n"
+            "2. 您目前已進入遊戲內的「彩繪貼圖組編輯器 (Vinyl Group Editor)」。\n"
+            "3. ⚠️【極度重要】您在編輯器內建立的圓形圖層數量，必須「恰好精準等於」下方數值，不能多也不能少：\n"
+            f"   👉 必須剛好是：{layers} 個未編組的圓形圖層！\n"
+            "   （若圖層數量有任何偏差，記憶體搜尋將會失敗，且可能導致注入崩潰！）\n\n"
+            "您是否確定要繼續執行記憶體注入？",
         )
 
         if not confirm:

--- a/fh6_painter_studio_gui.py
+++ b/fh6_painter_studio_gui.py
@@ -1192,6 +1192,11 @@ class ForzaStudioGUI:
                         data = json.load(f)
                     shapes = data.get("shapes", [])
                     if len(shapes) > 0:
+                        # QoL 2: 自動更新 Max Layer 控制項的值以匹配 JSON 裡的圖層數 (扣除第0層背景)
+                        num_layers = len(shapes) - 1
+                        if num_layers > 0:
+                            self.val_layers.set(str(num_layers))
+
                         header = shapes[0]
                         # Extract background dimensions and colors from header shape
                         h_data = header.get("data", [0.0, 0.0, 600.0, 600.0])
@@ -1418,6 +1423,13 @@ class ForzaStudioGUI:
                 self.status_lbl.configure(text="INJECT DONE", fg=self.color_blue)
                 self.log_to_console("\n[System] Livery memory injection completed.\n")
 
+                # QoL 2: 導入完成後，彈出傳統中文對話框提示玩家導入了多少幾何圖層
+                imported_layers = self.val_layers.get()
+                messagebox.showinfo(
+                    "導入成功 / Import Completed",
+                    f"彩繪圖層注入成功！\n共成功導入 {imported_layers} 個幾何圖層至遊戲記憶體中。",
+                )
+
         # Loop again in 100ms
         self.root.after(100, self.poll_background_updates)
 
@@ -1616,11 +1628,28 @@ class ForzaStudioGUI:
             messagebox.showerror("Error", f"Geometry JSON file not found:\n{json_path}")
             return
 
-        # Layers count based on GUI value (matching our search count)
-        try:
-            layers = int(self.val_layers.get())
-        except ValueError:
-            layers = 3000
+        # QoL 2: 載入 JSON 路徑時，自動解析 JSON 檔內的實體圖層數作為注入基準，免除手動設定
+        if json_path.lower().endswith(".json") and os.path.exists(json_path):
+            try:
+                import json
+                with open(json_path, "r", encoding="utf-8") as f:
+                    data = json.load(f)
+                shapes = data.get("shapes", [])
+                if len(shapes) > 0:
+                    layers = len(shapes) - 1
+                    self.val_layers.set(str(layers))
+                else:
+                    layers = 3000
+            except Exception:
+                try:
+                    layers = int(self.val_layers.get())
+                except ValueError:
+                    layers = 3000
+        else:
+            try:
+                layers = int(self.val_layers.get())
+            except ValueError:
+                layers = 3000
 
         # Confirm user opens ungrouped shapes
         confirm = messagebox.askyesno(

--- a/fh6_painter_studio_gui.py
+++ b/fh6_painter_studio_gui.py
@@ -1632,6 +1632,7 @@ class ForzaStudioGUI:
         if json_path.lower().endswith(".json") and os.path.exists(json_path):
             try:
                 import json
+
                 with open(json_path, "r", encoding="utf-8") as f:
                     data = json.load(f)
                 shapes = data.get("shapes", [])

--- a/optimization_settings.json
+++ b/optimization_settings.json
@@ -36,5 +36,12 @@
   "boundary_weighting": {
     "enabled": true,
     "bias": 3.0
+  },
+  "early_convergence": {
+    "enabled": true,
+    "check_interval": 100,
+    "start_eval_ratio": 0.5,
+    "redundancy_threshold": 0.75,
+    "target_integers": [500, 1000, 1500, 2000, 3000]
   }
 }

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -130,7 +130,7 @@ def test_early_convergence(temp_image_path):
             "check_interval": 2,
             "start_eval_ratio": 0.3,
             "redundancy_threshold": 0.0,  # 設為 0.0 強制觸發
-            "target_integers": [3]
+            "target_integers": [3],
         }
     }
 
@@ -173,8 +173,18 @@ def test_redundant_layer_consolidation():
     # 第一層是背景，第二層在 (8,8)，第三層在 (8,8) 完全遮擋第二層
     shapes_list = [
         {"type": 1, "data": [0.0, 0.0, 16.0, 16.0], "color": [255, 0, 0, 255]},
-        {"type": 32, "data": [8.0, 8.0, 4.0, 4.0, 0.0], "color": [0, 0, 255, 255], "score": 10.0},
-        {"type": 32, "data": [8.0, 8.0, 4.0, 4.0, 0.0], "color": [0, 0, 255, 255], "score": 5.0},
+        {
+            "type": 32,
+            "data": [8.0, 8.0, 4.0, 4.0, 0.0],
+            "color": [0, 0, 255, 255],
+            "score": 10.0,
+        },
+        {
+            "type": 32,
+            "data": [8.0, 8.0, 4.0, 4.0, 0.0],
+            "color": [0, 0, 255, 255],
+            "score": 5.0,
+        },
     ]
 
     evaluator = PurePythonEvaluator(np.zeros((16, 16, 3), dtype=np.float32))
@@ -191,4 +201,3 @@ def test_redundant_layer_consolidation():
     assert res[2]["data"][1] == 8.0
     assert res[2]["data"][2] == 0.01
     assert res[2]["data"][3] == 0.01
-

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -116,3 +116,79 @@ def test_generator_numba(temp_image_path):
     finally:
         if os.path.exists(out_path):
             os.remove(out_path)
+
+
+def test_early_convergence(temp_image_path):
+    """驗證提早收斂優化：是否能在飽和時將圖層收斂至目標整數。"""
+    with tempfile.NamedTemporaryFile(suffix=".json", delete=False) as f:
+        out_path = f.name
+    os.remove(out_path)
+
+    opt_settings = {
+        "early_convergence": {
+            "enabled": True,
+            "check_interval": 2,
+            "start_eval_ratio": 0.3,
+            "redundancy_threshold": 0.0,  # 設為 0.0 強制觸發
+            "target_integers": [3]
+        }
+    }
+
+    try:
+        # 目標設為 6 層，但因提早收斂應在第 2 或 4 層被強制收斂至 3 層
+        res = run_generator(
+            image_path=temp_image_path,
+            output_path=out_path,
+            layers_limit=6,
+            candidates_limit=10,
+            steps_limit=5,
+            opt_settings=opt_settings,
+            engine_name="PURE_PYTHON",
+        )
+
+        assert res == 0
+        assert os.path.exists(out_path)
+
+        with open(out_path, "r", encoding="utf-8") as f:
+            data = json.load(f)
+
+        shapes = data["shapes"]
+        # shapes 應該有 1 個背景 + 3 個收斂橢圓 = 4 個 shapes
+        assert len(shapes) == 4
+        assert shapes[0]["type"] == 1
+        assert shapes[1]["type"] == 32
+        assert shapes[2]["type"] == 32
+        assert shapes[3]["type"] == 32
+
+    finally:
+        if os.path.exists(out_path):
+            os.remove(out_path)
+
+
+def test_redundant_layer_consolidation():
+    """驗證棄用圖層優化 (QoL 1)：被拋棄圖層是否被移至末端且位置設在畫布中心。"""
+    from evaluators.pure_python_evaluator import PurePythonEvaluator
+
+    # 建立一個測試用的 shapes_list
+    # 第一層是背景，第二層在 (8,8)，第三層在 (8,8) 完全遮擋第二層
+    shapes_list = [
+        {"type": 1, "data": [0.0, 0.0, 16.0, 16.0], "color": [255, 0, 0, 255]},
+        {"type": 32, "data": [8.0, 8.0, 4.0, 4.0, 0.0], "color": [0, 0, 255, 255], "score": 10.0},
+        {"type": 32, "data": [8.0, 8.0, 4.0, 4.0, 0.0], "color": [0, 0, 255, 255], "score": 5.0},
+    ]
+
+    evaluator = PurePythonEvaluator(np.zeros((16, 16, 3), dtype=np.float32))
+    res = evaluator.run_redundancy_check(shapes_list, 16, 16, final_check=True)
+
+    # 驗證總長度依然為 3 (header + 1個有效 + 1個微型)
+    assert len(res) == 3
+    # 驗證有效圖層保持在上方
+    assert res[1]["score"] == 5.0
+    # 驗證被棄用的圖層被推到最末端 (index 2)
+    assert res[2]["score"] == 0.0
+    # 驗證棄用圖層的中心位置已改為畫布正中心 [16 / 2, 16 / 2] = [8.0, 8.0]
+    assert res[2]["data"][0] == 8.0
+    assert res[2]["data"][1] == 8.0
+    assert res[2]["data"][2] == 0.01
+    assert res[2]["data"][3] == 0.01
+

--- a/tools/fh6_painter_generator.py
+++ b/tools/fh6_painter_generator.py
@@ -222,6 +222,13 @@ def run_generator(
     decay_enabled = opt_decay.get("enabled", False)
     decay_min_max_r = opt_decay.get("min_max_r", 5.0)
 
+    opt_early = opt_settings.get("early_convergence", {})
+    early_enabled = opt_early.get("enabled", False)
+    early_interval = opt_early.get("check_interval", 100)
+    early_ratio = opt_early.get("start_eval_ratio", 0.5)
+    early_threshold = opt_early.get("redundancy_threshold", 0.75)
+    early_targets = opt_early.get("target_integers", [500, 1000, 1500, 2000, 3000])
+
     if profile_path:
         print(f"Profile: {os.path.basename(profile_path)}")
     print(f"Target: {image_path} -> Output: {output_path}")
@@ -422,6 +429,10 @@ def run_generator(
     if layers <= pyramid_layers_threshold * 2:
         stage_1_4_limit = max(10, int(layers * 0.25))
         stage_1_2_limit = max(20, int(layers * 0.50))
+
+    # 提早收斂優化追蹤變數
+    prev_valid_layers = 0
+    early_triggered = False
 
     try:
         while (len(shapes_list) - 1 < layers) and (attempts < max_attempts):
@@ -670,8 +681,14 @@ def run_generator(
                 and total_generated_so_far >= 10
                 and (total_generated_so_far - 10) % 10 == 0
             )
+            is_early_trigger = (
+                early_enabled
+                and not early_triggered
+                and total_generated_so_far >= int(early_ratio * layers)
+                and (total_generated_so_far % early_interval == 0)
+            )
 
-            if is_normal_trigger or is_test_trigger:
+            if is_normal_trigger or is_test_trigger or is_early_trigger:
                 print(
                     f"\n[Engine] Reached {total_generated_so_far} generated layers. Running mid-way redundancy check..."
                 )
@@ -690,6 +707,71 @@ def run_generator(
                         shapes_list,
                     )
                 current_layer = len(shapes_list) - 1
+
+                # 提早收斂飽和度評估與執行
+                if is_early_trigger:
+                    G = total_generated_so_far - prev_valid_layers
+                    retained = current_layer - prev_valid_layers
+                    if G > 0:
+                        redundancy_ratio = 1.0 - (retained / G)
+                        print(f"\n[Early Convergence] 飽和度評估 - 目前生成: {total_generated_so_far} 層 | 有效圖層: {current_layer} 層")
+                        print(f"[Early Convergence] 過去 {G} 層中，有效保留: {retained} 層 | 淘汰率: {redundancy_ratio*100:.1f}% (閾值: {early_threshold*100:.1f}%)")
+                        
+                        if redundancy_ratio >= early_threshold:
+                            print(f"\n[Early Convergence] 偵測到細節已飽和 (淘汰率 {redundancy_ratio*100:.1f}% >= 閾值 {early_threshold*100:.1f}%)！開始執行提早收斂...")
+                            
+                            # 尋找最接近的整數收斂目標 T (必須小於原目標 layers)
+                            best_t = layers
+                            min_diff = float('inf')
+                            for t in early_targets:
+                                if t < layers:
+                                    diff = abs(current_layer - t)
+                                    if diff < min_diff:
+                                        min_diff = diff
+                                        best_t = t
+                            
+                            print(f"[Early Convergence] 最接近的整數收斂目標為: {best_t} 層 (當前有效: {current_layer} 層)")
+                            
+                            # 雙向收斂執行
+                            if current_layer > best_t:
+                                # A > T：削減策略，排序剔除最不重要的圖層，並維持原始繪製順序
+                                print(f"[Early Convergence] 執行削減策略：從 {current_layer} 層中剔除最不重要的 {current_layer - best_t} 層...")
+                                
+                                # shapes_list[0] 是背景，shapes_list[1:] 是實際圖層
+                                indexed_shapes = [(idx, s) for idx, s in enumerate(shapes_list[1:])]
+                                # 按 score (Delta MSE 改善量) 從大到小排序，保留前 best_t 個
+                                indexed_shapes.sort(key=lambda item: item[1].get("score", 0.0), reverse=True)
+                                kept_indexed_shapes = indexed_shapes[:best_t]
+                                # 按原始索引排序以恢復原先的繪製先後順序
+                                kept_indexed_shapes.sort(key=lambda item: item[0])
+                                
+                                shapes_list = [shapes_list[0]] + [item[1] for item in kept_indexed_shapes]
+                                
+                                evaluator.rebuild_canvas(canvas, shapes_list, avg_r, avg_g, avg_b)
+                                if uncovered_enabled:
+                                    uncovered_map = rebuild_uncovered_map_from_shapes(
+                                        evaluator,
+                                        width,
+                                        height,
+                                        has_alpha,
+                                        alpha_mask,
+                                        uncovered_bias,
+                                        shapes_list,
+                                    )
+                                current_layer = len(shapes_list) - 1
+                                print(f"[Early Convergence] 削減成功，目前圖層已收斂至 {current_layer} 層！")
+                                
+                                layers = best_t
+                                early_triggered = True
+                                break  # 跳出生成迴圈！
+                            else:
+                                # A < T：補足策略，僅調低總目標 layers 繼續生成
+                                print(f"[Early Convergence] 執行補足策略：將目標層數 layers 調整為 {best_t} 層，繼續生成...")
+                                layers = best_t
+                                early_triggered = True
+
+                # 更新 prev_valid_layers 供下一次區間評估使用
+                prev_valid_layers = current_layer
 
             if current_layer in save_at or (
                 save_every > 0

--- a/tools/fh6_painter_generator.py
+++ b/tools/fh6_painter_generator.py
@@ -714,40 +714,59 @@ def run_generator(
                     retained = current_layer - prev_valid_layers
                     if G > 0:
                         redundancy_ratio = 1.0 - (retained / G)
-                        print(f"\n[Early Convergence] 飽和度評估 - 目前生成: {total_generated_so_far} 層 | 有效圖層: {current_layer} 層")
-                        print(f"[Early Convergence] 過去 {G} 層中，有效保留: {retained} 層 | 淘汰率: {redundancy_ratio*100:.1f}% (閾值: {early_threshold*100:.1f}%)")
-                        
+                        print(
+                            f"\n[Early Convergence] 飽和度評估 - 目前生成: {total_generated_so_far} 層 | 有效圖層: {current_layer} 層"
+                        )
+                        print(
+                            f"[Early Convergence] 過去 {G} 層中，有效保留: {retained} 層 | 淘汰率: {redundancy_ratio * 100:.1f}% (閾值: {early_threshold * 100:.1f}%)"
+                        )
+
                         if redundancy_ratio >= early_threshold:
-                            print(f"\n[Early Convergence] 偵測到細節已飽和 (淘汰率 {redundancy_ratio*100:.1f}% >= 閾值 {early_threshold*100:.1f}%)！開始執行提早收斂...")
-                            
+                            print(
+                                f"\n[Early Convergence] 偵測到細節已飽和 (淘汰率 {redundancy_ratio * 100:.1f}% >= 閾值 {early_threshold * 100:.1f}%)！開始執行提早收斂..."
+                            )
+
                             # 尋找最接近的整數收斂目標 T (必須小於原目標 layers)
                             best_t = layers
-                            min_diff = float('inf')
+                            min_diff = float("inf")
                             for t in early_targets:
                                 if t < layers:
                                     diff = abs(current_layer - t)
                                     if diff < min_diff:
                                         min_diff = diff
                                         best_t = t
-                            
-                            print(f"[Early Convergence] 最接近的整數收斂目標為: {best_t} 層 (當前有效: {current_layer} 層)")
-                            
+
+                            print(
+                                f"[Early Convergence] 最接近的整數收斂目標為: {best_t} 層 (當前有效: {current_layer} 層)"
+                            )
+
                             # 雙向收斂執行
                             if current_layer > best_t:
                                 # A > T：削減策略，排序剔除最不重要的圖層，並維持原始繪製順序
-                                print(f"[Early Convergence] 執行削減策略：從 {current_layer} 層中剔除最不重要的 {current_layer - best_t} 層...")
-                                
+                                print(
+                                    f"[Early Convergence] 執行削減策略：從 {current_layer} 層中剔除最不重要的 {current_layer - best_t} 層..."
+                                )
+
                                 # shapes_list[0] 是背景，shapes_list[1:] 是實際圖層
-                                indexed_shapes = [(idx, s) for idx, s in enumerate(shapes_list[1:])]
+                                indexed_shapes = [
+                                    (idx, s) for idx, s in enumerate(shapes_list[1:])
+                                ]
                                 # 按 score (Delta MSE 改善量) 從大到小排序，保留前 best_t 個
-                                indexed_shapes.sort(key=lambda item: item[1].get("score", 0.0), reverse=True)
+                                indexed_shapes.sort(
+                                    key=lambda item: item[1].get("score", 0.0),
+                                    reverse=True,
+                                )
                                 kept_indexed_shapes = indexed_shapes[:best_t]
                                 # 按原始索引排序以恢復原先的繪製先後順序
                                 kept_indexed_shapes.sort(key=lambda item: item[0])
-                                
-                                shapes_list = [shapes_list[0]] + [item[1] for item in kept_indexed_shapes]
-                                
-                                evaluator.rebuild_canvas(canvas, shapes_list, avg_r, avg_g, avg_b)
+
+                                shapes_list = [shapes_list[0]] + [
+                                    item[1] for item in kept_indexed_shapes
+                                ]
+
+                                evaluator.rebuild_canvas(
+                                    canvas, shapes_list, avg_r, avg_g, avg_b
+                                )
                                 if uncovered_enabled:
                                     uncovered_map = rebuild_uncovered_map_from_shapes(
                                         evaluator,
@@ -759,14 +778,18 @@ def run_generator(
                                         shapes_list,
                                     )
                                 current_layer = len(shapes_list) - 1
-                                print(f"[Early Convergence] 削減成功，目前圖層已收斂至 {current_layer} 層！")
-                                
+                                print(
+                                    f"[Early Convergence] 削減成功，目前圖層已收斂至 {current_layer} 層！"
+                                )
+
                                 layers = best_t
                                 early_triggered = True
                                 break  # 跳出生成迴圈！
                             else:
                                 # A < T：補足策略，僅調低總目標 layers 繼續生成
-                                print(f"[Early Convergence] 執行補足策略：將目標層數 layers 調整為 {best_t} 層，繼續生成...")
+                                print(
+                                    f"[Early Convergence] 執行補足策略：將目標層數 layers 調整為 {best_t} 層，繼續生成..."
+                                )
                                 layers = best_t
                                 early_triggered = True
 


### PR DESCRIPTION
我們在 feature/early-convergence 分支上完成了以下程式碼重構：

1. 提早收斂引擎核心
位置：
fh6_painter_generator.py
實作細節：
新增 early_convergence 配置組解析，支援動態設定監測區間、啟動進度、淘汰率閾值與目標整數層數。
在生成迴圈中維護飽和度監測器，計算最近一個區間的有效圖層淘汰率。
削減收斂策略 (A>T)：將圖層按 Delta MSE 改善量排序，剔除最不重要的圖層，並使用原始索引重新排序以保持遮擋（繪製前後）關係，重新繪製畫布，隨後重置 layers = T 並退出迴圈。
補足收斂策略 (A<T)：自動將 layers 調低至最接近的整數 T，並繼續生成至 T 自然結束。

2. QoL 1：棄用圖層優化
位置：
numba_evaluator.py
 與 
pure_python_evaluator.py
實作細節：
在 run_redundancy_check(final_check=True) 時，分離有效圖層與冗餘圖層。
被拋棄的冗餘圖層尺寸重設為微型，座標重置為畫布正中心 [width / 2.0, height / 2.0]，以便於玩家在遊戲內選取編輯。
將所有冗餘圖層打包推到圖層清單的最上層（末尾），保證所有有效圖層排列在下方，絕不破壞原先的順序與整潔。

3. QoL 2：注入層數偵測
位置：
fh6_painter_studio_gui.py
實作細節：
自動匹配 Max Layer：在載入 JSON 幾何檔進行預覽時，程式自動解析圖層數（排除背景）並寫入 self.val_layers，免除玩家手動調整欄位的麻煩。
強制實體層數注入：在進行 Win32 記憶體注入時，若選擇了 JSON 檔，注入器會自動以 JSON 中的實際幾何數做為注入基準。
導入完成繁體中文提示：在記憶體寫入完成時，彈出 messagebox.showinfo 提示框，顯示：「彩繪圖層注入成功！共成功導入 XXX 個幾何圖層至遊戲記憶體中。」