### PR TITLE
feat: 重構早期收斂策略為一律補足收斂（以 50 層為步進向上取整）

### DIFF
--- a/optimization_settings.json
+++ b/optimization_settings.json
@@ -42,12 +42,6 @@
     "check_interval": 100,
     "start_eval_ratio": 0.5,
     "redundancy_threshold": 0.75,
-    "target_integers": [
-      500,
-      1000,
-      1500,
-      2000,
-      3000
-    ]
+    "convergence_step": 50
   }
 }

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -119,7 +119,7 @@ def test_generator_numba(temp_image_path):
 
 
 def test_early_convergence(temp_image_path):
-    """驗證提早收斂優化：是否能在飽和時將圖層收斂至目標整數。"""
+    """驗證提早收斂優化：是否能在飽和時將圖層收斂至最接近的步進倍數並補足收斂。"""
     with tempfile.NamedTemporaryFile(suffix=".json", delete=False) as f:
         out_path = f.name
     os.remove(out_path)
@@ -128,20 +128,20 @@ def test_early_convergence(temp_image_path):
         "early_convergence": {
             "enabled": True,
             "check_interval": 2,
-            "start_eval_ratio": 0.3,
+            "start_eval_ratio": 0.01,
             "redundancy_threshold": 0.0,  # 設為 0.0 強制觸發
-            "target_integers": [3],
+            "convergence_step": 3,  # 自訂步進以利測試
         }
     }
 
     try:
-        # 目標設為 6 層，但因提早收斂應在第 2 或 4 層被強制收斂至 3 層
+        # 目標設為 6 層，在第 2 層觸發提早收斂，收斂目標應向上取整為 3 層 (步進為 3)
         res = run_generator(
             image_path=temp_image_path,
             output_path=out_path,
             layers_limit=6,
-            candidates_limit=10,
-            steps_limit=5,
+            candidates_limit=5,
+            steps_limit=2,
             opt_settings=opt_settings,
             engine_name="PURE_PYTHON",
         )
@@ -153,12 +153,10 @@ def test_early_convergence(temp_image_path):
             data = json.load(f)
 
         shapes = data["shapes"]
-        # shapes 應該有 1 個背景 + 3 個收斂橢圓 = 4 個 shapes
+        # shapes 應該有 1 個背景 + 3 個收斂橢圓 = 4 個 shapes (而不是原定的 6 個)
         assert len(shapes) == 4
         assert shapes[0]["type"] == 1
-        assert shapes[1]["type"] == 32
-        assert shapes[2]["type"] == 32
-        assert shapes[3]["type"] == 32
+        assert all(s["type"] == 32 for s in shapes[1:])
 
     finally:
         if os.path.exists(out_path):

--- a/tools/fh6_painter_generator.py
+++ b/tools/fh6_painter_generator.py
@@ -227,7 +227,7 @@ def run_generator(
     early_interval = opt_early.get("check_interval", 100)
     early_ratio = opt_early.get("start_eval_ratio", 0.5)
     early_threshold = opt_early.get("redundancy_threshold", 0.75)
-    early_targets = opt_early.get("target_integers", [500, 1000, 1500, 2000, 3000])
+    early_step = opt_early.get("convergence_step", 50)
 
     if profile_path:
         print(f"Profile: {os.path.basename(profile_path)}")
@@ -431,6 +431,7 @@ def run_generator(
         stage_1_2_limit = max(20, int(layers * 0.50))
 
     # 提早收斂優化追蹤變數
+    original_layers = layers
     prev_valid_layers = 0
     early_triggered = False
 
@@ -726,72 +727,24 @@ def run_generator(
                                 f"\n[Early Convergence] 偵測到細節已飽和 (淘汰率 {redundancy_ratio * 100:.1f}% >= 閾值 {early_threshold * 100:.1f}%)！開始執行提早收斂..."
                             )
 
-                            # 尋找最接近的整數收斂目標 T (必須小於原目標 layers)
-                            best_t = layers
-                            min_diff = float("inf")
-                            for t in early_targets:
-                                if t < layers:
-                                    diff = abs(current_layer - t)
-                                    if diff < min_diff:
-                                        min_diff = diff
-                                        best_t = t
-
-                            print(
-                                f"[Early Convergence] 最接近的整數收斂目標為: {best_t} 層 (當前有效: {current_layer} 層)"
+                            # 收斂層數則以 early_step 為步進向上取整，且不得超過原定最大層數 original_layers
+                            best_t = min(
+                                int(math.ceil(current_layer / float(early_step)))
+                                * early_step,
+                                original_layers,
                             )
 
-                            # 雙向收斂執行
-                            if current_layer > best_t:
-                                # A > T：削減策略，排序剔除最不重要的圖層，並維持原始繪製順序
+                            print(
+                                f"[Early Convergence] 執行補足策略：將目標層數 layers 調整為 {best_t} 層 (當前有效: {current_layer} 層)"
+                            )
+                            layers = best_t
+                            early_triggered = True
+
+                            if current_layer >= layers:
                                 print(
-                                    f"[Early Convergence] 執行削減策略：從 {current_layer} 層中剔除最不重要的 {current_layer - best_t} 層..."
+                                    "[Early Convergence] 當前層數已達到或超過收斂目標，停止生成。"
                                 )
-
-                                # shapes_list[0] 是背景，shapes_list[1:] 是實際圖層
-                                indexed_shapes = [
-                                    (idx, s) for idx, s in enumerate(shapes_list[1:])
-                                ]
-                                # 按 score (Delta MSE 改善量) 從大到小排序，保留前 best_t 個
-                                indexed_shapes.sort(
-                                    key=lambda item: item[1].get("score", 0.0),
-                                    reverse=True,
-                                )
-                                kept_indexed_shapes = indexed_shapes[:best_t]
-                                # 按原始索引排序以恢復原先的繪製先後順序
-                                kept_indexed_shapes.sort(key=lambda item: item[0])
-
-                                shapes_list = [shapes_list[0]] + [
-                                    item[1] for item in kept_indexed_shapes
-                                ]
-
-                                evaluator.rebuild_canvas(
-                                    canvas, shapes_list, avg_r, avg_g, avg_b
-                                )
-                                if uncovered_enabled:
-                                    uncovered_map = rebuild_uncovered_map_from_shapes(
-                                        evaluator,
-                                        width,
-                                        height,
-                                        has_alpha,
-                                        alpha_mask,
-                                        uncovered_bias,
-                                        shapes_list,
-                                    )
-                                current_layer = len(shapes_list) - 1
-                                print(
-                                    f"[Early Convergence] 削減成功，目前圖層已收斂至 {current_layer} 層！"
-                                )
-
-                                layers = best_t
-                                early_triggered = True
-                                break  # 跳出生成迴圈！
-                            else:
-                                # A < T：補足策略，僅調低總目標 layers 繼續生成
-                                print(
-                                    f"[Early Convergence] 執行補足策略：將目標層數 layers 調整為 {best_t} 層，繼續生成..."
-                                )
-                                layers = best_t
-                                early_triggered = True
+                                break
 
                 # 更新 prev_valid_layers 供下一次區間評估使用
                 prev_valid_layers = current_layer


### PR DESCRIPTION
## 變更摘要 (Summary of Changes)
修正先前削減（Pruning）收斂策略導致細節遺失的問題，改為「一律補足收斂」並引入靈活步進機制：
1. **補足收斂邏輯實作**：移除原有排序剔除圖層的削減策略（A > T）。當偵測到細節飽和時，一律將目標圖層數向上取整至最接近的步進倍數，並補足繪製直到該層數。
2. **靈活步進設計**：在 `early_convergence` 模組中引入 `convergence_step` 設定（預設為 50），並套用 `math.ceil` 向上取整公式計算收斂目標，且限制不超過原始設定的最大圖層數。
3. **優化配置更新**：刪除已無作用的 `target_integers` 選項，改用清晰的 `"convergence_step": 50`。
4. **健全的單元測試**：重構 `test_generator.py` 中的 `test_early_convergence`，採用自訂測試步進 (`convergence_step: 3`) 與 `layers_limit: 6`，在不超出 16x16 測試圖實體冗餘上限的情況下，完美覆蓋「向上取整」與「補足收斂」的關鍵路徑。

## 測試與驗證結果 (Verification Results)
- 本地使用 `ruff` 進行格式化與靜態風格分析，所有檢查均順利通過（All checks passed!）。
- 本地執行 `pytest` 單元測試，全部 21 項測試均無誤通過。