### PR TITLE
fix: Upgrade static layer pointer cache to dynamic table address cache to fix issue #23

### DIFF
--- a/tests/test_importer.py
+++ b/tests/test_importer.py
@@ -131,6 +131,53 @@ class TestImporter(unittest.TestCase):
         self.assertEqual(shapes[0]["data"], [0.0, 0.0, 100.0, 100.0])
         self.assertEqual(shapes[1]["type"], 2)
 
+    @patch("tools.fh6_import_layer_table.try_read")
+    @patch("tools.fh6_import_layer_table.read_u64")
+    @patch("tools.fh6_import_layer_table.score_layer")
+    def test_cache_mechanism(self, mock_score_layer, mock_read_u64, mock_try_read):
+        import struct
+        cache_file = "test_layer_table.cache"
+        if os.path.exists(cache_file):
+            os.remove(cache_file)
+
+        try:
+            pid = 12345
+            layers = 4
+            group_addr = 0x1000
+            table_addr = 0x2000
+            pointers = [0x3000, 0x30B0, 0x3160, 0x3210]
+
+            # Test save_cached_layer_pointers
+            fh6_importer.save_cached_layer_pointers(
+                cache_file, pid, layers, group_addr, table_addr, pointers
+            )
+            self.assertTrue(os.path.exists(cache_file))
+
+            # Mock responses for verification in try_load_cached_layer_pointers
+            # 1. read group count: GROUP_COUNT_OFFSET = 0x5A
+            # Struct format "<I" is 4 bytes. We return count as 4
+            mock_try_read.side_effect = [
+                struct.pack("<I", 4),  # First call: try_read for count
+                struct.pack("<4Q", *pointers)  # Second call: try_read for pointers table
+            ]
+            # 2. read table pointer at group_addr + GROUP_TABLE_OFFSET (0x78)
+            mock_read_u64.return_value = table_addr
+            # 3. score each layer
+            mock_score_layer.return_value = 5
+
+            loaded_pointers = fh6_importer.try_load_cached_layer_pointers(
+                handle=None, cache_path=cache_file, pid=pid, layer_count=layers
+            )
+
+            self.assertEqual(loaded_pointers, pointers)
+            
+            # Verify read_u64 was called with group_addr + GROUP_TABLE_OFFSET
+            mock_read_u64.assert_called_with(None, group_addr + fh6_importer.GROUP_TABLE_OFFSET)
+
+        finally:
+            if os.path.exists(cache_file):
+                os.remove(cache_file)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_importer.py
+++ b/tests/test_importer.py
@@ -170,7 +170,7 @@ class TestImporter(unittest.TestCase):
             )
 
             self.assertEqual(loaded_pointers, pointers)
-            
+
             # Verify read_u64 was called with group_addr + GROUP_TABLE_OFFSET
             mock_read_u64.assert_called_with(None, group_addr + fh6_importer.GROUP_TABLE_OFFSET)
 

--- a/tests/test_importer.py
+++ b/tests/test_importer.py
@@ -136,6 +136,7 @@ class TestImporter(unittest.TestCase):
     @patch("tools.fh6_import_layer_table.score_layer")
     def test_cache_mechanism(self, mock_score_layer, mock_read_u64, mock_try_read):
         import struct
+
         cache_file = "test_layer_table.cache"
         if os.path.exists(cache_file):
             os.remove(cache_file)
@@ -158,7 +159,9 @@ class TestImporter(unittest.TestCase):
             # Struct format "<I" is 4 bytes. We return count as 4
             mock_try_read.side_effect = [
                 struct.pack("<I", 4),  # First call: try_read for count
-                struct.pack("<4Q", *pointers)  # Second call: try_read for pointers table
+                struct.pack(
+                    "<4Q", *pointers
+                ),  # Second call: try_read for pointers table
             ]
             # 2. read table pointer at group_addr + GROUP_TABLE_OFFSET (0x78)
             mock_read_u64.return_value = table_addr
@@ -172,7 +175,9 @@ class TestImporter(unittest.TestCase):
             self.assertEqual(loaded_pointers, pointers)
 
             # Verify read_u64 was called with group_addr + GROUP_TABLE_OFFSET
-            mock_read_u64.assert_called_with(None, group_addr + fh6_importer.GROUP_TABLE_OFFSET)
+            mock_read_u64.assert_called_with(
+                None, group_addr + fh6_importer.GROUP_TABLE_OFFSET
+            )
 
         finally:
             if os.path.exists(cache_file):

--- a/tools/fh6_import_layer_table.py
+++ b/tools/fh6_import_layer_table.py
@@ -703,7 +703,7 @@ def locate_layer_pointers(handle, layer_count, max_candidates):
         for i in range(layer_count):
             pointers.append(read_u64(handle, best_table + i * 8))
 
-    return pointers
+    return pointers, best_group, best_table
 
 
 # --- Caching Support ---
@@ -719,12 +719,15 @@ def try_load_cached_layer_pointers(handle, cache_path, pid, layer_count):
             return None
 
         header = lines[0].split("|")
-        if len(header) != 2:
-            print("Layer cache header is invalid; full scan needed.")
+        if len(header) < 4:
+            print("Layer cache header is invalid or old format; full scan needed.")
             return None
 
         cached_pid = int(header[0])
         cached_layers = int(header[1])
+        cached_group = int(header[2], 16)
+        cached_table = int(header[3], 16)
+
         if cached_pid != pid:
             print("Layer cache is from another FH6 process; full scan needed.")
             return None
@@ -732,14 +735,33 @@ def try_load_cached_layer_pointers(handle, cache_path, pid, layer_count):
             print("Layer cache is for a different layer count; full scan needed.")
             return None
 
+        # Verify group count in game memory to make sure count matches
+        count_bytes = try_read(handle, cached_group + GROUP_COUNT_OFFSET, 4)
+        if not count_bytes:
+            print("Failed to read group count from memory; cache is invalid.")
+            return None
+        current_count = struct.unpack("<I", count_bytes)[0]
+        if current_count != layer_count:
+            print(f"Group layer count changed in memory ({current_count} != {layer_count}); cache is invalid.")
+            return None
+
+        # Verify group table pointer in game memory
+        table_ptr = read_u64(handle, cached_group + GROUP_TABLE_OFFSET)
+        if table_ptr != cached_table:
+            print(f"Group table pointer changed in memory; cache is invalid.")
+            return None
+
+        # Dynamically read layer pointers from the table in game memory
         pointers = []
-        for line in lines[1:]:
-            pointers.append(int(line, 16))
-            if len(pointers) == layer_count:
-                break
+        table_data = try_read(handle, cached_table, layer_count * 8)
+        if table_data and len(table_data) == layer_count * 8:
+            pointers = list(struct.unpack(f"<{layer_count}Q", table_data))
+        else:
+            for i in range(layer_count):
+                pointers.append(read_u64(handle, cached_table + i * 8))
 
         if len(pointers) != layer_count:
-            print("Layer cache pointer count does not match; full scan needed.")
+            print("Failed to read pointers from table; full scan needed.")
             return None
 
         valid = 0
@@ -753,17 +775,17 @@ def try_load_cached_layer_pointers(handle, cache_path, pid, layer_count):
             )
             return None
 
-        print(f"Using cached layer pointers valid={valid}/{layer_count}")
+        print(f"Using cached layer pointers valid={valid}/{layer_count} (dynamically read from table 0x{cached_table:X})")
         return pointers
     except Exception as e:
         print(f"Layer cache could not be read; full scan needed. Error: {e}")
         return None
 
 
-def save_cached_layer_pointers(cache_path, pid, layer_count, pointers):
+def save_cached_layer_pointers(cache_path, pid, layer_count, group_addr, table_addr, pointers):
     try:
         with open(cache_path, "w", encoding="utf-8") as f:
-            f.write(f"{pid}|{layer_count}\n")
+            f.write(f"{pid}|{layer_count}|{group_addr:X}|{table_addr:X}\n")
             for ptr in pointers:
                 f.write(f"{ptr:X}\n")
     except Exception as e:
@@ -928,8 +950,8 @@ def run_importer(
             )
 
             if layer_pointers is None:
-                layer_pointers = locate_layer_pointers(handle, layers, max_candidates)
-                save_cached_layer_pointers(cache_path, pid, layers, layer_pointers)
+                layer_pointers, best_group, best_table = locate_layer_pointers(handle, layers, max_candidates)
+                save_cached_layer_pointers(cache_path, pid, layers, best_group, best_table, layer_pointers)
 
             print(f"LiveryGroup found. Valid layer pointers={len(layer_pointers)}")
 

--- a/tools/fh6_import_layer_table.py
+++ b/tools/fh6_import_layer_table.py
@@ -748,7 +748,7 @@ def try_load_cached_layer_pointers(handle, cache_path, pid, layer_count):
         # Verify group table pointer in game memory
         table_ptr = read_u64(handle, cached_group + GROUP_TABLE_OFFSET)
         if table_ptr != cached_table:
-            print(f"Group table pointer changed in memory; cache is invalid.")
+            print("Group table pointer changed in memory; cache is invalid.")
             return None
 
         # Dynamically read layer pointers from the table in game memory

--- a/tools/fh6_import_layer_table.py
+++ b/tools/fh6_import_layer_table.py
@@ -742,7 +742,9 @@ def try_load_cached_layer_pointers(handle, cache_path, pid, layer_count):
             return None
         current_count = struct.unpack("<I", count_bytes)[0]
         if current_count != layer_count:
-            print(f"Group layer count changed in memory ({current_count} != {layer_count}); cache is invalid.")
+            print(
+                f"Group layer count changed in memory ({current_count} != {layer_count}); cache is invalid."
+            )
             return None
 
         # Verify group table pointer in game memory
@@ -775,14 +777,18 @@ def try_load_cached_layer_pointers(handle, cache_path, pid, layer_count):
             )
             return None
 
-        print(f"Using cached layer pointers valid={valid}/{layer_count} (dynamically read from table 0x{cached_table:X})")
+        print(
+            f"Using cached layer pointers valid={valid}/{layer_count} (dynamically read from table 0x{cached_table:X})"
+        )
         return pointers
     except Exception as e:
         print(f"Layer cache could not be read; full scan needed. Error: {e}")
         return None
 
 
-def save_cached_layer_pointers(cache_path, pid, layer_count, group_addr, table_addr, pointers):
+def save_cached_layer_pointers(
+    cache_path, pid, layer_count, group_addr, table_addr, pointers
+):
     try:
         with open(cache_path, "w", encoding="utf-8") as f:
             f.write(f"{pid}|{layer_count}|{group_addr:X}|{table_addr:X}\n")
@@ -950,8 +956,12 @@ def run_importer(
             )
 
             if layer_pointers is None:
-                layer_pointers, best_group, best_table = locate_layer_pointers(handle, layers, max_candidates)
-                save_cached_layer_pointers(cache_path, pid, layers, best_group, best_table, layer_pointers)
+                layer_pointers, best_group, best_table = locate_layer_pointers(
+                    handle, layers, max_candidates
+                )
+                save_cached_layer_pointers(
+                    cache_path, pid, layers, best_group, best_table, layer_pointers
+                )
 
             print(f"LiveryGroup found. Valid layer pointers={len(layer_pointers)}")
 


### PR DESCRIPTION
### 關聯 Issue
- 修正 #23

### 根本原因與問題分析
在先前的設計中，快取機制 (`fh6-layer-table.cache`) 僅儲存了靜態的圖層記憶體結構指標 (`layerPtr`)。
然而，如果玩家在 Forza Horizon 6 的編輯器中進行了重排圖層 (調整 Z-Order)、刪除或群組/取消群組等操作，這些圖層記憶體指標雖然依舊有效，但它們在指標表中的順序與成員已經與遊戲實際畫面不同步。這導致快取被判定為有效載入，但最終寫入的位址順序完全錯誤，引發大約 300~700 層的注入失敗或順序錯亂問題。

### 解決方案與改動
本 PR 將「靜態指標快取」升級為「動態表位址快取」，提供即時與安全的動態驗證：
1. **快取格式升級**：在快取 Header 中除了 PID 和圖層數外，新增儲存 `group_addr` (圖層組位址) 與 `table_addr` (圖層指標表位址)。
2. **動態讀取與驗證**：載入快取時，先從遊戲記憶體中讀取並驗證 `group_addr` 下的圖層數量與指標表位址。
3. **即時同步**：驗證通過後，直接**從遊戲記憶體的 `table_addr` 處動態讀取最新的指標列表**，而非使用快取檔案中舊的靜態指針對照，確保不論圖層如何重排，寫入的順序永遠與遊戲即時狀態完全一致。
4. **健全的退回機制**：當玩家退出編輯器、切換車輛或變更圖層數量時，該位址將自動驗證失敗，安全地退回到完整的記憶體掃描重新獲取。

### 測試與驗證
- 在 `tests/test_importer.py` 中新增 `test_cache_mechanism` 單元測試，模擬新型 Header 解析、動態記憶體讀取與評分驗證之全部核心流程。
- 本地所有單元測試已全部通過（PASS）：
  ```powershell
  .venv\Scripts\python -m unittest discover -s tests
  # Ran 13 tests in 0.016s -> OK