### PR TITLE
⚡ Bolt: Hoist division operations in optimization loops

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -13,3 +13,6 @@
 ## 2026-06-01 - Pure Python Scanline Rendering Optimization
 **Learning:** The analytical scanline solver (quadratic roots based on sine/cosine projections) previously used in Numba and Taichi JIT kernels also significantly boosts performance in Pure Python environments without explicit vectorization. It eliminates conditional branching inside tight inner loops, which is inherently slow in CPython due to evaluation overhead.
 **Action:** Apply the analytical scanline solver to purely Python bounding box iteration loops where mathematical solutions are faster than procedural pixel-by-pixel boundary checking, reducing evaluation time during fallback operations.
+## 2026-06-02 - Division Hoisting: alpha / 255.0
+**Learning:** I found multiple instances where `alpha / 255.0` and `step / optimization_steps` were being computed repeatedly inside of loops in `evaluators/pure_python_evaluator.py`, `evaluators/numba_kernels.py`, and `evaluators/taichi_evaluator.py`. Since divisions are slow, especially in inner loops, replacing division by multiplication using precalculated constants (`alpha * 0.00392156862745098` and `step * inv_opt_steps`) can yield a performance improvement.
+**Action:** Replaced division operations with equivalent multiplication using hoisted reciprocal values or pre-calculated constants across evaluator kernels.

--- a/evaluators/numba_kernels.py
+++ b/evaluators/numba_kernels.py
@@ -460,7 +460,11 @@ def serial_hill_climb(
     T = np.float32(initial_temp)
     c_rate = np.float32(cooling_rate)
     max_r_f = np.float32(max_r)
-    inv_opt_steps = np.float32(1.0 / optimization_steps) if optimization_steps > 0 else np.float32(0.0)
+    inv_opt_steps = (
+        np.float32(1.0 / optimization_steps)
+        if optimization_steps > 0
+        else np.float32(0.0)
+    )
 
     for step in range(optimization_steps):
         scale = np.float32(1.0 - (step * inv_opt_steps))

--- a/evaluators/numba_kernels.py
+++ b/evaluators/numba_kernels.py
@@ -169,7 +169,7 @@ def evaluate_candidate(
     avg_g = sum_t_g * inv_count
     avg_b = sum_t_b * inv_count
 
-    a_f = np.float32(alpha / 255.0)
+    a_f = np.float32(alpha * 0.00392156862745098)
     a2_minus_2a = np.float32(a_f * a_f - 2.0 * a_f)
     two_a = np.float32(2.0 * a_f)
     two_a_one_minus_a = np.float32(2.0 * a_f * (1.0 - a_f))
@@ -218,7 +218,7 @@ def draw_ellipse(canvas, x_c, y_c, r_x, r_y, theta, r, g, b, alpha):
     inv_rx2 = np.float32(1.0 / (r_x * r_x) if r_x > 0 else 0.0)
     inv_ry2 = np.float32(1.0 / (r_y * r_y) if r_y > 0 else 0.0)
 
-    a_f = np.float32(alpha / 255.0)
+    a_f = np.float32(alpha * 0.00392156862745098)
     one_minus_a = np.float32(1.0 - a_f)
 
     r_val = np.float32(r)
@@ -460,9 +460,10 @@ def serial_hill_climb(
     T = np.float32(initial_temp)
     c_rate = np.float32(cooling_rate)
     max_r_f = np.float32(max_r)
+    inv_opt_steps = np.float32(1.0 / optimization_steps) if optimization_steps > 0 else np.float32(0.0)
 
     for step in range(optimization_steps):
-        scale = np.float32(1.0 - (step / optimization_steps))
+        scale = np.float32(1.0 - (step * inv_opt_steps))
 
         nx_c = curr_x_c + np.float32(np.random.normal(0.0, 8.0 * scale))
         ny_c = curr_y_c + np.float32(np.random.normal(0.0, 8.0 * scale))
@@ -564,7 +565,7 @@ def run_redundancy_check_jit(shapes_data, shapes_color, shapes_type, width, heig
         theta = np.float32(shapes_data[i, 4])
 
         alpha = shapes_color[i, 3]
-        a_f = np.float32(alpha / 255.0)
+        a_f = np.float32(alpha * 0.00392156862745098)
 
         cos_t = np.float32(math.cos(theta))
         sin_t = np.float32(math.sin(theta))

--- a/evaluators/pure_python_evaluator.py
+++ b/evaluators/pure_python_evaluator.py
@@ -422,7 +422,11 @@ class PurePythonEvaluator(BaseEvaluator):
         max_r_f = np.float32(max_r)
         sa_enabled = params.get("sa_enabled", False)
         optimization_steps = params.get("optimization_steps", 50)
-        inv_opt_steps = np.float32(1.0 / optimization_steps) if optimization_steps > 0 else np.float32(0.0)
+        inv_opt_steps = (
+            np.float32(1.0 / optimization_steps)
+            if optimization_steps > 0
+            else np.float32(0.0)
+        )
 
         for step in range(optimization_steps):
             scale = np.float32(1.0 - (step * inv_opt_steps))

--- a/evaluators/pure_python_evaluator.py
+++ b/evaluators/pure_python_evaluator.py
@@ -152,11 +152,12 @@ def evaluate_candidate_py(
     if count == 0:
         return np.float32(0.0), np.float32(0.0), np.float32(0.0), np.float32(99999999.0)
 
-    avg_r = sum_t_r / count
-    avg_g = sum_t_g / count
-    avg_b = sum_t_b / count
+    inv_count = 1.0 / count
+    avg_r = sum_t_r * inv_count
+    avg_g = sum_t_g * inv_count
+    avg_b = sum_t_b * inv_count
 
-    a_f = np.float32(alpha / 255.0)
+    a_f = np.float32(alpha * 0.00392156862745098)
     a2_minus_2a = np.float32(a_f * a_f - 2.0 * a_f)
     two_a = np.float32(2.0 * a_f)
     two_a_one_minus_a = np.float32(2.0 * a_f * (1.0 - a_f))
@@ -204,7 +205,7 @@ def draw_ellipse_py(canvas, x_c, y_c, r_x, r_y, theta, r, g, b, alpha):
     inv_rx2 = np.float32(1.0 / (r_x * r_x) if r_x > 0 else 0.0)
     inv_ry2 = np.float32(1.0 / (r_y * r_y) if r_y > 0 else 0.0)
 
-    a_f = np.float32(alpha / 255.0)
+    a_f = np.float32(alpha * 0.00392156862745098)
     one_minus_a = np.float32(1.0 - a_f)
 
     r_val = np.float32(r)
@@ -421,9 +422,10 @@ class PurePythonEvaluator(BaseEvaluator):
         max_r_f = np.float32(max_r)
         sa_enabled = params.get("sa_enabled", False)
         optimization_steps = params.get("optimization_steps", 50)
+        inv_opt_steps = np.float32(1.0 / optimization_steps) if optimization_steps > 0 else np.float32(0.0)
 
         for step in range(optimization_steps):
-            scale = np.float32(1.0 - (step / optimization_steps))
+            scale = np.float32(1.0 - (step * inv_opt_steps))
 
             nx_c = curr_x_c + np.float32(np.random.normal(0.0, 8.0 * scale))
             ny_c = curr_y_c + np.float32(np.random.normal(0.0, 8.0 * scale))
@@ -574,7 +576,7 @@ class PurePythonEvaluator(BaseEvaluator):
             x_c, y_c, r_x, r_y, theta_deg = data
             theta = math.radians(theta_deg)
             alpha = color[3] if len(color) >= 4 else 255
-            a_f = np.float32(alpha / 255.0)
+            a_f = np.float32(alpha * 0.00392156862745098)
 
             cos_t = np.float32(math.cos(theta))
             sin_t = np.float32(math.sin(theta))

--- a/evaluators/taichi_evaluator.py
+++ b/evaluators/taichi_evaluator.py
@@ -212,7 +212,7 @@ def evaluate_candidate_ti(
         avg_g = sum_t_g * inv_count
         avg_b = sum_t_b * inv_count
 
-        a_f = alpha / 255.0
+        a_f = alpha * 0.00392156862745098
         a2_minus_2a = a_f * a_f - 2.0 * a_f
         two_a = 2.0 * a_f
         two_a_one_minus_a = 2.0 * a_f * (1.0 - a_f)
@@ -508,7 +508,7 @@ def draw_ellipse_gpu(
     inv_rx2 = 1.0 / (r_x * r_x) if r_x > 0.0 else 0.0
     inv_ry2 = 1.0 / (r_y * r_y) if r_y > 0.0 else 0.0
 
-    a_f = alpha / 255.0
+    a_f = alpha * 0.00392156862745098
     one_minus_a = 1.0 - a_f
 
     sin_cos = sin_t * cos_t
@@ -605,9 +605,10 @@ def parallel_hill_climb_gpu(
         curr_delta = best_candidate[0, 9]
 
         T = sa_initial_temp
+        inv_opt_steps = 1.0 / ti.cast(optimization_steps, ti.f32) if optimization_steps > 0 else 0.0
 
         for step in range(optimization_steps):
-            scale = 1.0 - (ti.cast(step, ti.f32) / ti.cast(optimization_steps, ti.f32))
+            scale = 1.0 - (ti.cast(step, ti.f32) * inv_opt_steps)
 
             u1 = ti.random()
             u2 = ti.random()

--- a/evaluators/taichi_evaluator.py
+++ b/evaluators/taichi_evaluator.py
@@ -605,7 +605,9 @@ def parallel_hill_climb_gpu(
         curr_delta = best_candidate[0, 9]
 
         T = sa_initial_temp
-        inv_opt_steps = 1.0 / ti.cast(optimization_steps, ti.f32) if optimization_steps > 0 else 0.0
+        inv_opt_steps = (
+            1.0 / ti.cast(optimization_steps, ti.f32) if optimization_steps > 0 else 0.0
+        )
 
         for step in range(optimization_steps):
             scale = 1.0 - (ti.cast(step, ti.f32) * inv_opt_steps)


### PR DESCRIPTION
💡 What: Replaced division operations (`alpha / 255.0` and `step / optimization_steps`) inside inner optimization loops with multiplication by pre-calculated constants (`alpha * 0.00392156862745098` and `step * inv_opt_steps`) across `evaluators/pure_python_evaluator.py`, `evaluators/numba_kernels.py`, and `evaluators/taichi_evaluator.py`.

🎯 Why: Divisions are computationally expensive, especially when repeatedly executed within hot inner loops. Hoisting the division by precalculating the reciprocal and performing multiplication instead yields measurable performance improvements without sacrificing accuracy or readability.

📊 Impact: Reduces computational overhead in tight loops across Numba JIT, Taichi GPU, and Pure Python evaluation engines, delivering faster shape rendering times.

🔬 Measurement: Verified the improvement using `tools/benchmark_taichi.py`. Also ran all unit tests via `pytest tests/` (with Xvfb) to ensure functional correctness.

---
*PR created automatically by Jules for task [3053421092672446107](https://jules.google.com/task/3053421092672446107) started by @eddie772tw*