### PR TITLE
⚡ Bolt: Manual Loop Unswitching in JIT Kernels

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -16,3 +16,7 @@
 ## 2026-06-02 - Division Hoisting: alpha / 255.0
 **Learning:** I found multiple instances where `alpha / 255.0` and `step / optimization_steps` were being computed repeatedly inside of loops in `evaluators/pure_python_evaluator.py`, `evaluators/numba_kernels.py`, and `evaluators/taichi_evaluator.py`. Since divisions are slow, especially in inner loops, replacing division by multiplication using precalculated constants (`alpha * 0.00392156862745098` and `step * inv_opt_steps`) can yield a performance improvement.
 **Action:** Replaced division operations with equivalent multiplication using hoisted reciprocal values or pre-calculated constants across evaluator kernels.
+
+## 2026-06-03 - Loop Unswitching in JIT Kernels
+**Learning:** In highly intensive accumulation loops (like those evaluating thousands of ellipse candidates), runtime boolean flags (e.g., `use_weight`, `use_uncovered`) inside the inner loops prevent compilers (LLVM/Taichi) from fully vectorizing and unswitching the loops automatically due to complexity thresholds. This results in millions of redundant branch evaluations and multiplications by 1.0 (or its typecast equivalent).
+**Action:** Apply manual loop unswitching by branching on these boolean flags outside the main pixel-processing `y`/`x` loops. Create a dedicated "fast path" loop for the default configuration that completely omits weight computation and multiplications, significantly boosting throughput.

--- a/evaluators/numba_kernels.py
+++ b/evaluators/numba_kernels.py
@@ -117,49 +117,90 @@ def evaluate_candidate(
     sum_ct_b = np.float32(0.0)
 
     # Heavy Accumulation Loop: Contiguous memory access, zero branching, highly vectorizable (AVX2/FMA3)
-    for y in range(min_y, max_y + 1):
-        dy = np.float32(y - y_c)
-        b_quad = dy * b_coeff
-        c_val = dy * dy * c_y_coeff - 1.0
-        discriminant = b_quad * b_quad - a * c_val
-        if discriminant >= 0.0:
-            sqrt_d = math.sqrt(discriminant)
-            dx_min = (-b_quad - sqrt_d) * inv_a
-            dx_max = (-b_quad + sqrt_d) * inv_a
-            x_start = max(min_x, int(math.ceil(x_c + dx_min)))
-            x_end = min(max_x, int(math.floor(x_c + dx_max)))
+    if not use_weight and not use_uncovered:
+        # Fast Path (No weights)
+        for y in range(min_y, max_y + 1):
+            dy = np.float32(y - y_c)
+            b_quad = dy * b_coeff
+            c_val = dy * dy * c_y_coeff - 1.0
+            discriminant = b_quad * b_quad - a * c_val
+            if discriminant >= 0.0:
+                sqrt_d = math.sqrt(discriminant)
+                dx_min = (-b_quad - sqrt_d) * inv_a
+                dx_max = (-b_quad + sqrt_d) * inv_a
+                x_start = max(min_x, int(math.ceil(x_c + dx_min)))
+                x_end = min(max_x, int(math.floor(x_c + dx_max)))
 
-            for x in range(x_start, x_end + 1):
-                t_r = target_r[y, x]
-                t_g = target_g[y, x]
-                t_b = target_b[y, x]
+                for x in range(x_start, x_end + 1):
+                    t_r = target_r[y, x]
+                    t_g = target_g[y, x]
+                    t_b = target_b[y, x]
 
-                c_r = canvas_r[y, x]
-                c_g = canvas_g[y, x]
-                c_b = canvas_b[y, x]
+                    c_r = canvas_r[y, x]
+                    c_g = canvas_g[y, x]
+                    c_b = canvas_b[y, x]
 
-                w = np.float32(1.0)
-                if use_weight:
-                    w = weight_map[y, x]
-                if use_uncovered:
-                    w = w * uncovered_map[y, x]
+                    count += np.float32(1.0)
+                    sum_t_r += t_r
+                    sum_t_g += t_g
+                    sum_t_b += t_b
 
-                count += w
-                sum_t_r += t_r * w
-                sum_t_g += t_g * w
-                sum_t_b += t_b * w
+                    sum_c_r += c_r
+                    sum_c_g += c_g
+                    sum_c_b += c_b
 
-                sum_c_r += c_r * w
-                sum_c_g += c_g * w
-                sum_c_b += c_b * w
+                    sum_c2_r += c_r * c_r
+                    sum_c2_g += c_g * c_g
+                    sum_c2_b += c_b * c_b
 
-                sum_c2_r += (c_r * c_r) * w
-                sum_c2_g += (c_g * c_g) * w
-                sum_c2_b += (c_b * c_b) * w
+                    sum_ct_r += c_r * t_r
+                    sum_ct_g += c_g * t_g
+                    sum_ct_b += c_b * t_b
+    else:
+        # Slow Path (With weights)
+        for y in range(min_y, max_y + 1):
+            dy = np.float32(y - y_c)
+            b_quad = dy * b_coeff
+            c_val = dy * dy * c_y_coeff - 1.0
+            discriminant = b_quad * b_quad - a * c_val
+            if discriminant >= 0.0:
+                sqrt_d = math.sqrt(discriminant)
+                dx_min = (-b_quad - sqrt_d) * inv_a
+                dx_max = (-b_quad + sqrt_d) * inv_a
+                x_start = max(min_x, int(math.ceil(x_c + dx_min)))
+                x_end = min(max_x, int(math.floor(x_c + dx_max)))
 
-                sum_ct_r += (c_r * t_r) * w
-                sum_ct_g += (c_g * t_g) * w
-                sum_ct_b += (c_b * t_b) * w
+                for x in range(x_start, x_end + 1):
+                    t_r = target_r[y, x]
+                    t_g = target_g[y, x]
+                    t_b = target_b[y, x]
+
+                    c_r = canvas_r[y, x]
+                    c_g = canvas_g[y, x]
+                    c_b = canvas_b[y, x]
+
+                    w = np.float32(1.0)
+                    if use_weight:
+                        w = weight_map[y, x]
+                    if use_uncovered:
+                        w = w * uncovered_map[y, x]
+
+                    count += w
+                    sum_t_r += t_r * w
+                    sum_t_g += t_g * w
+                    sum_t_b += t_b * w
+
+                    sum_c_r += c_r * w
+                    sum_c_g += c_g * w
+                    sum_c_b += c_b * w
+
+                    sum_c2_r += (c_r * c_r) * w
+                    sum_c2_g += (c_g * c_g) * w
+                    sum_c2_b += (c_b * c_b) * w
+
+                    sum_ct_r += (c_r * t_r) * w
+                    sum_ct_g += (c_g * t_g) * w
+                    sum_ct_b += (c_b * t_b) * w
 
     if count == 0:
         return np.float32(0.0), np.float32(0.0), np.float32(0.0), np.float32(99999999.0)

--- a/evaluators/pure_python_evaluator.py
+++ b/evaluators/pure_python_evaluator.py
@@ -105,49 +105,90 @@ def evaluate_candidate_py(
                         )
 
     # Accumulation Pass
-    for y in range(min_y, max_y + 1):
-        dy = np.float32(y - y_c)
-        b_quad = dy * b_coeff
-        c_val = dy * dy * c_y_coeff - 1.0
-        discriminant = b_quad * b_quad - a * c_val
-        if discriminant >= 0.0:
-            sqrt_d = math.sqrt(discriminant)
-            dx_min = (-b_quad - sqrt_d) * inv_a
-            dx_max = (-b_quad + sqrt_d) * inv_a
-            x_start = max(min_x, int(math.ceil(x_c + dx_min)))
-            x_end = min(max_x, int(math.floor(x_c + dx_max)))
+    if not use_weight and not use_uncovered:
+        # Fast Path (No weights)
+        for y in range(min_y, max_y + 1):
+            dy = np.float32(y - y_c)
+            b_quad = dy * b_coeff
+            c_val = dy * dy * c_y_coeff - 1.0
+            discriminant = b_quad * b_quad - a * c_val
+            if discriminant >= 0.0:
+                sqrt_d = math.sqrt(discriminant)
+                dx_min = (-b_quad - sqrt_d) * inv_a
+                dx_max = (-b_quad + sqrt_d) * inv_a
+                x_start = max(min_x, int(math.ceil(x_c + dx_min)))
+                x_end = min(max_x, int(math.floor(x_c + dx_max)))
 
-            for x in range(x_start, x_end + 1):
-                t_r = target[y, x, 0]
-                t_g = target[y, x, 1]
-                t_b = target[y, x, 2]
+                for x in range(x_start, x_end + 1):
+                    t_r = target[y, x, 0]
+                    t_g = target[y, x, 1]
+                    t_b = target[y, x, 2]
 
-                c_r = canvas[y, x, 0]
-                c_g = canvas[y, x, 1]
-                c_b = canvas[y, x, 2]
+                    c_r = canvas[y, x, 0]
+                    c_g = canvas[y, x, 1]
+                    c_b = canvas[y, x, 2]
 
-                w = np.float32(1.0)
-                if use_weight:
-                    w = weight_map[y, x]
-                if use_uncovered:
-                    w = w * uncovered_map[y, x]
+                    count += np.float32(1.0)
+                    sum_t_r += t_r
+                    sum_t_g += t_g
+                    sum_t_b += t_b
 
-                count += w
-                sum_t_r += t_r * w
-                sum_t_g += t_g * w
-                sum_t_b += t_b * w
+                    sum_c_r += c_r
+                    sum_c_g += c_g
+                    sum_c_b += c_b
 
-                sum_c_r += c_r * w
-                sum_c_g += c_g * w
-                sum_c_b += c_b * w
+                    sum_c2_r += c_r * c_r
+                    sum_c2_g += c_g * c_g
+                    sum_c2_b += c_b * c_b
 
-                sum_c2_r += (c_r * c_r) * w
-                sum_c2_g += (c_g * c_g) * w
-                sum_c2_b += (c_b * c_b) * w
+                    sum_ct_r += c_r * t_r
+                    sum_ct_g += c_g * t_g
+                    sum_ct_b += c_b * t_b
+    else:
+        # Slow Path (With weights)
+        for y in range(min_y, max_y + 1):
+            dy = np.float32(y - y_c)
+            b_quad = dy * b_coeff
+            c_val = dy * dy * c_y_coeff - 1.0
+            discriminant = b_quad * b_quad - a * c_val
+            if discriminant >= 0.0:
+                sqrt_d = math.sqrt(discriminant)
+                dx_min = (-b_quad - sqrt_d) * inv_a
+                dx_max = (-b_quad + sqrt_d) * inv_a
+                x_start = max(min_x, int(math.ceil(x_c + dx_min)))
+                x_end = min(max_x, int(math.floor(x_c + dx_max)))
 
-                sum_ct_r += (c_r * t_r) * w
-                sum_ct_g += (c_g * t_g) * w
-                sum_ct_b += (c_b * t_b) * w
+                for x in range(x_start, x_end + 1):
+                    t_r = target[y, x, 0]
+                    t_g = target[y, x, 1]
+                    t_b = target[y, x, 2]
+
+                    c_r = canvas[y, x, 0]
+                    c_g = canvas[y, x, 1]
+                    c_b = canvas[y, x, 2]
+
+                    w = np.float32(1.0)
+                    if use_weight:
+                        w = weight_map[y, x]
+                    if use_uncovered:
+                        w = w * uncovered_map[y, x]
+
+                    count += w
+                    sum_t_r += t_r * w
+                    sum_t_g += t_g * w
+                    sum_t_b += t_b * w
+
+                    sum_c_r += c_r * w
+                    sum_c_g += c_g * w
+                    sum_c_b += c_b * w
+
+                    sum_c2_r += (c_r * c_r) * w
+                    sum_c2_g += (c_g * c_g) * w
+                    sum_c2_b += (c_b * c_b) * w
+
+                    sum_ct_r += (c_r * t_r) * w
+                    sum_ct_g += (c_g * t_g) * w
+                    sum_ct_b += (c_b * t_b) * w
 
     if count == 0:
         return np.float32(0.0), np.float32(0.0), np.float32(0.0), np.float32(99999999.0)

--- a/evaluators/taichi_evaluator.py
+++ b/evaluators/taichi_evaluator.py
@@ -153,53 +153,104 @@ def evaluate_candidate_ti(
 
         # Accumulation Pass (Perfect for coalesced parallel loads)
         if is_valid == 1:
-            y = min_y
-            while y <= max_y:
-                dy = ti.cast(y, ti.f32) - y_c
-                b_val = dy * b_coeff
-                c_val = dy * dy * c_y_coeff - 1.0
-                discriminant = b_val * b_val - a * c_val
-                if discriminant >= 0.0:
-                    sqrt_d = ti.math.sqrt(discriminant)
-                    dx_min = (-b_val - sqrt_d) * inv_a
-                    dx_max = (-b_val + sqrt_d) * inv_a
-                    x_start = ti.max(min_x, ti.cast(ti.math.ceil(x_c + dx_min), ti.i32))
-                    x_end = ti.min(max_x, ti.cast(ti.math.floor(x_c + dx_max), ti.i32))
+            if use_weight == 0 and use_uncovered == 0:
+                y = min_y
+                while y <= max_y:
+                    dy = ti.cast(y, ti.f32) - y_c
+                    b_val = dy * b_coeff
+                    c_val = dy * dy * c_y_coeff - 1.0
+                    discriminant = b_val * b_val - a * c_val
+                    if discriminant >= 0.0:
+                        sqrt_d = ti.math.sqrt(discriminant)
+                        dx_min = (-b_val - sqrt_d) * inv_a
+                        dx_max = (-b_val + sqrt_d) * inv_a
+                        x_start = ti.max(
+                            min_x, ti.cast(ti.math.ceil(x_c + dx_min), ti.i32)
+                        )
+                        x_end = ti.min(
+                            max_x, ti.cast(ti.math.floor(x_c + dx_max), ti.i32)
+                        )
 
-                    x = x_start
-                    while x <= x_end:
-                        t_r = target_r[y, x]
-                        t_g = target_g[y, x]
-                        t_b = target_b[y, x]
+                        x = x_start
+                        while x <= x_end:
+                            t_r = target_r[y, x]
+                            t_g = target_g[y, x]
+                            t_b = target_b[y, x]
 
-                        c_r = canvas_r[y, x]
-                        c_g = canvas_g[y, x]
-                        c_b = canvas_b[y, x]
+                            c_r = canvas_r[y, x]
+                            c_g = canvas_g[y, x]
+                            c_b = canvas_b[y, x]
 
-                        w = 1.0
-                        if use_weight == 1:
-                            w = weight_map[y, x]
-                        if use_uncovered == 1:
-                            w = w * uncovered_map[y, x]
+                            count += 1.0
+                            sum_t_r += t_r
+                            sum_t_g += t_g
+                            sum_t_b += t_b
 
-                        count += w
-                        sum_t_r += t_r * w
-                        sum_t_g += t_g * w
-                        sum_t_b += t_b * w
+                            sum_c_r += c_r
+                            sum_c_g += c_g
+                            sum_c_b += c_b
 
-                        sum_c_r += c_r * w
-                        sum_c_g += c_g * w
-                        sum_c_b += c_b * w
+                            sum_c2_r += c_r * c_r
+                            sum_c2_g += c_g * c_g
+                            sum_c2_b += c_b * c_b
 
-                        sum_c2_r += (c_r * c_r) * w
-                        sum_c2_g += (c_g * c_g) * w
-                        sum_c2_b += (c_b * c_b) * w
+                            sum_ct_r += c_r * t_r
+                            sum_ct_g += c_g * t_g
+                            sum_ct_b += c_b * t_b
+                            x += 1
+                    y += 1
+            else:
+                y = min_y
+                while y <= max_y:
+                    dy = ti.cast(y, ti.f32) - y_c
+                    b_val = dy * b_coeff
+                    c_val = dy * dy * c_y_coeff - 1.0
+                    discriminant = b_val * b_val - a * c_val
+                    if discriminant >= 0.0:
+                        sqrt_d = ti.math.sqrt(discriminant)
+                        dx_min = (-b_val - sqrt_d) * inv_a
+                        dx_max = (-b_val + sqrt_d) * inv_a
+                        x_start = ti.max(
+                            min_x, ti.cast(ti.math.ceil(x_c + dx_min), ti.i32)
+                        )
+                        x_end = ti.min(
+                            max_x, ti.cast(ti.math.floor(x_c + dx_max), ti.i32)
+                        )
 
-                        sum_ct_r += (c_r * t_r) * w
-                        sum_ct_g += (c_g * t_g) * w
-                        sum_ct_b += (c_b * t_b) * w
-                        x += 1
-                y += 1
+                        x = x_start
+                        while x <= x_end:
+                            t_r = target_r[y, x]
+                            t_g = target_g[y, x]
+                            t_b = target_b[y, x]
+
+                            c_r = canvas_r[y, x]
+                            c_g = canvas_g[y, x]
+                            c_b = canvas_b[y, x]
+
+                            w = 1.0
+                            if use_weight == 1:
+                                w = weight_map[y, x]
+                            if use_uncovered == 1:
+                                w = w * uncovered_map[y, x]
+
+                            count += w
+                            sum_t_r += t_r * w
+                            sum_t_g += t_g * w
+                            sum_t_b += t_b * w
+
+                            sum_c_r += c_r * w
+                            sum_c_g += c_g * w
+                            sum_c_b += c_b * w
+
+                            sum_c2_r += (c_r * c_r) * w
+                            sum_c2_g += (c_g * c_g) * w
+                            sum_c2_b += (c_b * c_b) * w
+
+                            sum_ct_r += (c_r * t_r) * w
+                            sum_ct_g += (c_g * t_g) * w
+                            sum_ct_b += (c_b * t_b) * w
+                            x += 1
+                    y += 1
 
     avg_r = 0.0
     avg_g = 0.0

--- a/fh6_painter_studio_gui.py
+++ b/fh6_painter_studio_gui.py
@@ -1409,7 +1409,7 @@ class ForzaStudioGUI:
 
         hdr = tk.Frame(bench_win, bg=self.bg_card)
         hdr.pack(fill="x", padx=10, pady=(10, 5), ipady=4)
-        
+
         lbl = tk.Label(
             hdr,
             text="🏆 性能基準測試主控台 / Performance Benchmark Console",
@@ -1455,9 +1455,13 @@ class ForzaStudioGUI:
         def worker():
             import subprocess
             import sys
-            
-            script_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), "tools", "benchmark_taichi.py")
-            
+
+            script_path = os.path.join(
+                os.path.dirname(os.path.abspath(__file__)),
+                "tools",
+                "benchmark_taichi.py",
+            )
+
             try:
                 # Use sys.executable to run in unbuffered mode so stdout streams line-by-line
                 process = subprocess.Popen(
@@ -1466,45 +1470,56 @@ class ForzaStudioGUI:
                     stderr=subprocess.STDOUT,
                     text=True,
                     bufsize=1,
-                    cwd=os.path.dirname(os.path.abspath(__file__))
+                    cwd=os.path.dirname(os.path.abspath(__file__)),
                 )
-                
-                for line in iter(process.stdout.readline, ''):
+
+                for line in iter(process.stdout.readline, ""):
                     # Append output line-by-line to the text box
-                    txt_widget.after(0, lambda l=line: (
-                        txt_widget.configure(state="normal"),
-                        txt_widget.insert(tk.END, l),
-                        txt_widget.see(tk.END),
-                        txt_widget.configure(state="disabled")
-                    ))
-                
+                    txt_widget.after(
+                        0,
+                        lambda l=line: (
+                            txt_widget.configure(state="normal"),
+                            txt_widget.insert(tk.END, l),
+                            txt_widget.see(tk.END),
+                            txt_widget.configure(state="disabled"),
+                        ),
+                    )
+
                 process.stdout.close()
                 return_code = process.wait()
-                
+
                 if return_code == 0:
                     status_text = "PASSED / SUCCESS"
                     status_color = self.color_green
                 else:
                     status_text = "FAILED / REGRESSION WARNING"
                     status_color = "#D32F2F"
-                    
-                txt_widget.after(0, lambda: (
-                    status_lbl.configure(text=status_text, fg=status_color)
-                ))
+
+                txt_widget.after(
+                    0, lambda: status_lbl.configure(text=status_text, fg=status_color)
+                )
             except Exception as e:
-                txt_widget.after(0, lambda err=e: (
-                    txt_widget.configure(state="normal"),
-                    txt_widget.insert(tk.END, f"\n[Benchmark Execution Error] {err}\n"),
-                    txt_widget.see(tk.END),
-                    txt_widget.configure(state="disabled"),
-                    status_lbl.configure(text="ERROR", fg="#D32F2F")
-                ))
+                txt_widget.after(
+                    0,
+                    lambda err=e: (
+                        txt_widget.configure(state="normal"),
+                        txt_widget.insert(
+                            tk.END, f"\n[Benchmark Execution Error] {err}\n"
+                        ),
+                        txt_widget.see(tk.END),
+                        txt_widget.configure(state="disabled"),
+                        status_lbl.configure(text="ERROR", fg="#D32F2F"),
+                    ),
+                )
             finally:
                 # Always unlock main GUI after completion
-                txt_widget.after(0, lambda: (
-                    self.status_lbl.configure(text="READY", fg="#888888"),
-                    self.unlock_ui()
-                ))
+                txt_widget.after(
+                    0,
+                    lambda: (
+                        self.status_lbl.configure(text="READY", fg="#888888"),
+                        self.unlock_ui(),
+                    ),
+                )
 
         # Launch the subprocess in a daemon thread so the GUI remains perfectly responsive!
         t = threading.Thread(target=worker, daemon=True)


### PR DESCRIPTION
💡 **What:** Implemented manual loop unswitching in the core `evaluate_candidate` functions across all three compute backends (`evaluators/numba_kernels.py`, `evaluators/taichi_evaluator.py`, `evaluators/pure_python_evaluator.py`).
🎯 **Why:** To prevent LLVM/Taichi compilers from failing to unswitch loops automatically due to complexity thresholds. Previously, boolean runtime flags (`use_weight`, `use_uncovered`) caused millions of redundant branch evaluations and `w = 1.0` multiplications inside the hottest inner loop.
📊 **Impact:** Significantly reduces inner-loop computational overhead during shape evaluation by providing a dedicated, branchless "fast path" for the default unweighted scenario.
🔬 **Measurement:** Verified via the full test suite (`pytest tests/`) showing no regressions in numerical accuracy or boundary checking logic. Use `benchmark_taichi.py` to observe raw execution speedups across CPU/GPU backends.

---
*PR created automatically by Jules for task [14637293876910240265](https://jules.google.com/task/14637293876910240265) started by @eddie772tw*