### PR TITLE
Fix LiveryGroup memory injection validation failure

### DIFF
--- a/evaluators/taichi_evaluator.py
+++ b/evaluators/taichi_evaluator.py
@@ -441,6 +441,10 @@ def update_uncovered_mask_gpu(
     height: ti.i32,
     width: ti.i32,
 ):
+    # Force access to prevent JIT compiler from optimizing out unused ndarray arguments on some Vulkan drivers
+    if height == -1:
+        uncovered_map[0, 0] = best_candidate[0, 0]
+
     x_c = best_candidate[0, 0]
     y_c = best_candidate[0, 1]
     r_x = best_candidate[0, 2]
@@ -547,6 +551,10 @@ def draw_ellipse_gpu(
     height: ti.i32,
     width: ti.i32,
 ):
+    # Force access to prevent JIT compiler from optimizing out unused ndarray arguments on some Vulkan drivers
+    if height == -1:
+        canvas[0, 0, 0] = best_candidate[0, 0]
+
     x_c = best_candidate[0, 0]
     y_c = best_candidate[0, 1]
     r_x = best_candidate[0, 2]

--- a/fh6_painter_studio_gui.py
+++ b/fh6_painter_studio_gui.py
@@ -2047,8 +2047,13 @@ class ForzaStudioGUI:
 
                     messagebox.showerror(
                         "導入失敗 / Import Failed",
-                        "彩繪圖層注入失敗！\n請檢查終端機日誌以確認錯誤原因。\n\n"
-                        "提示：如果錯誤是 LastError=5 (Access Denied)，請關閉程式並以「系統管理員身分執行」重試。",
+                        "彩繪圖層注入失敗！無任何級別的候選者通過驗證。\n\n"
+                        "請點擊右上角「診斷主控台 / Show Logs」查看詳細驗證失敗原因。\n\n"
+                        "常見疑難排解：\n"
+                        "1. 確保您已進入編輯器並建立了正確數量的圓形圖層。\n"
+                        "2. ⚠️ 確保所有圓形圖層都已「解除群組 (Ungrouped)」。\n"
+                        "3. 嘗試退出編輯器再重新進入，並重新建立圖層。\n"
+                        "4. 如果 Log 顯示 LastError=5 (Access Denied)，請以「系統管理員身分」重啟本程式。",
                     )
 
         # Loop again in 100ms

--- a/tests/test_mock_scanner.py
+++ b/tests/test_mock_scanner.py
@@ -1,0 +1,133 @@
+import unittest
+from unittest.mock import MagicMock, patch, ANY
+import ctypes
+import struct
+import os
+import sys
+
+# Add the project root to sys.path to allow importing from tools
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import tools.fh6_import_layer_table as importer
+
+class TestMockScanner(unittest.TestCase):
+    @patch("tools.fh6_import_layer_table.kernel32")
+    def test_enumerate_regions_broad(self, mock_kernel32):
+        # We need a way to fill the MBI structure.
+        self.assertEqual(importer.MEM_MAPPED, 0x40000)
+        self.assertEqual(importer.MEM_IMAGE, 0x1000000)
+
+        mbi_data = []
+        # 1. Private
+        m1 = importer.MEMORY_BASIC_INFORMATION64()
+        m1.BaseAddress = 0x0
+        m1.RegionSize = 0x1000
+        m1.State = importer.MEM_COMMIT
+        m1.Type = importer.MEM_PRIVATE
+        m1.Protect = importer.PAGE_READWRITE
+        mbi_data.append(m1)
+
+        # 2. Mapped
+        m2 = importer.MEMORY_BASIC_INFORMATION64()
+        m2.BaseAddress = 0x1000
+        m2.RegionSize = 0x1000
+        m2.State = importer.MEM_COMMIT
+        m2.Type = importer.MEM_MAPPED
+        m2.Protect = importer.PAGE_READWRITE
+        mbi_data.append(m2)
+
+        # 3. Image
+        m3 = importer.MEMORY_BASIC_INFORMATION64()
+        m3.BaseAddress = 0x2000
+        m3.RegionSize = 0x1000
+        m3.State = importer.MEM_COMMIT
+        m3.Type = importer.MEM_IMAGE
+        m3.Protect = importer.PAGE_READWRITE
+        mbi_data.append(m3)
+
+        idx = 0
+        def mock_vq(handle, address, mbi_ptr, size):
+            nonlocal idx
+            if idx >= len(mbi_data):
+                return 0
+            ctypes.memmove(mbi_ptr, ctypes.addressof(mbi_data[idx]), size)
+            idx += 1
+            return size
+
+        mock_kernel32.VirtualQueryEx.side_effect = mock_vq
+
+        regions = importer.enumerate_regions(None)
+        self.assertEqual(len(regions), 3)
+        self.assertEqual(regions[0]["Type"], importer.MEM_PRIVATE)
+        self.assertEqual(regions[1]["Type"], importer.MEM_MAPPED)
+        self.assertEqual(regions[2]["Type"], importer.MEM_IMAGE)
+
+    @patch("tools.fh6_import_layer_table.try_read")
+    @patch("tools.fh6_import_layer_table.is_user_ptr")
+    @patch("tools.fh6_import_layer_table.read_2_floats")
+    def test_score_layer_adaptive_details(self, mock_read_2_floats, mock_is_user_ptr, mock_try_read):
+        mock_is_user_ptr.return_value = True
+
+        # Scenario: Position is out of range
+        mock_read_2_floats.side_effect = [
+            (99999.0, 0.0), # pos: Fail
+            (1.0, 1.0)      # scale: Pass
+        ]
+        mock_try_read.side_effect = [
+            bytes([255, 255, 255, 255]), # color: Pass
+            bytes([importer.SHAPE_ID_ELLIPSE]), # shape: Pass
+            bytes([0]) # mask: Pass
+        ]
+
+        score, detail = importer.score_layer_adaptive(None, 0x1234, importer.StrictnessLevel.PERFECT, return_detail=True)
+        self.assertEqual(score, 4)
+        self.assertIn("Pos invalid", detail)
+
+    @patch("tools.fh6_import_layer_table.enumerate_regions")
+    @patch("tools.fh6_import_layer_table.try_read")
+    @patch("tools.fh6_import_layer_table.read_u64")
+    @patch("tools.fh6_import_layer_table.is_user_ptr")
+    @patch("tools.fh6_import_layer_table.score_layer_adaptive")
+    @patch("tools.fh6_import_layer_table.count_valid_layers_adaptive")
+    def test_locate_layer_pointers_with_mapped_region(self, mock_count_valid, mock_score_adaptive, mock_is_user_ptr, mock_read_u64, mock_try_read, mock_enumerate):
+        # Setup regions: one mapped region containing the pattern
+        mock_enumerate.return_value = [
+            {"Base": 0x10000, "Size": 0x1000, "Protect": importer.PAGE_READWRITE, "Type": importer.MEM_MAPPED}
+        ]
+
+        layer_count = 100
+        pattern = struct.pack("<I", layer_count)
+
+        chunk = bytearray(importer.CHUNK_SIZE)
+        offset = 100
+        chunk[offset:offset+4] = pattern
+
+        mock_try_read.side_effect = [
+            chunk, # scan_region_task
+            struct.pack("<Q", 0x3000), # read_u64(table_addr) inside the loop
+            # table_data for final pointers read
+            struct.pack("<100Q", *[0x4000+i for i in range(100)])
+        ]
+
+        mock_read_u64.return_value = 0x20000
+        mock_is_user_ptr.return_value = True
+
+        def score_side_effect(handle, ptr, level, return_detail=False):
+            if return_detail:
+                return (5, "")
+            return 5
+        mock_score_adaptive.side_effect = score_side_effect
+
+        mock_count_valid.return_value = 100
+
+        with patch("tools.fh6_import_layer_table.HeuristicsManager") as mock_hm:
+            mock_hm_inst = mock_hm.return_value
+            mock_hm_inst.data = {"successful_regions": []}
+
+            pointers, group, table = importer.locate_layer_pointers(None, layer_count, 1000)
+
+            self.assertEqual(table, 0x20000)
+            self.assertEqual(len(pointers), 100)
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_mock_scanner.py
+++ b/tests/test_mock_scanner.py
@@ -1,14 +1,15 @@
-import unittest
-from unittest.mock import MagicMock, patch, ANY
 import ctypes
-import struct
 import os
+import struct
 import sys
+import unittest
+from unittest.mock import ANY, MagicMock, patch
 
 # Add the project root to sys.path to allow importing from tools
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 import tools.fh6_import_layer_table as importer
+
 
 class TestMockScanner(unittest.TestCase):
     @patch("tools.fh6_import_layer_table.kernel32")
@@ -46,6 +47,7 @@ class TestMockScanner(unittest.TestCase):
         mbi_data.append(m3)
 
         idx = 0
+
         def mock_vq(handle, address, mbi_ptr, size):
             nonlocal idx
             if idx >= len(mbi_data):
@@ -65,21 +67,25 @@ class TestMockScanner(unittest.TestCase):
     @patch("tools.fh6_import_layer_table.try_read")
     @patch("tools.fh6_import_layer_table.is_user_ptr")
     @patch("tools.fh6_import_layer_table.read_2_floats")
-    def test_score_layer_adaptive_details(self, mock_read_2_floats, mock_is_user_ptr, mock_try_read):
+    def test_score_layer_adaptive_details(
+        self, mock_read_2_floats, mock_is_user_ptr, mock_try_read
+    ):
         mock_is_user_ptr.return_value = True
 
         # Scenario: Position is out of range
         mock_read_2_floats.side_effect = [
-            (99999.0, 0.0), # pos: Fail
-            (1.0, 1.0)      # scale: Pass
+            (99999.0, 0.0),  # pos: Fail
+            (1.0, 1.0),  # scale: Pass
         ]
         mock_try_read.side_effect = [
-            bytes([255, 255, 255, 255]), # color: Pass
-            bytes([importer.SHAPE_ID_ELLIPSE]), # shape: Pass
-            bytes([0]) # mask: Pass
+            bytes([255, 255, 255, 255]),  # color: Pass
+            bytes([importer.SHAPE_ID_ELLIPSE]),  # shape: Pass
+            bytes([0]),  # mask: Pass
         ]
 
-        score, detail = importer.score_layer_adaptive(None, 0x1234, importer.StrictnessLevel.PERFECT, return_detail=True)
+        score, detail = importer.score_layer_adaptive(
+            None, 0x1234, importer.StrictnessLevel.PERFECT, return_detail=True
+        )
         self.assertEqual(score, 4)
         self.assertIn("Pos invalid", detail)
 
@@ -89,10 +95,23 @@ class TestMockScanner(unittest.TestCase):
     @patch("tools.fh6_import_layer_table.is_user_ptr")
     @patch("tools.fh6_import_layer_table.score_layer_adaptive")
     @patch("tools.fh6_import_layer_table.count_valid_layers_adaptive")
-    def test_locate_layer_pointers_with_mapped_region(self, mock_count_valid, mock_score_adaptive, mock_is_user_ptr, mock_read_u64, mock_try_read, mock_enumerate):
+    def test_locate_layer_pointers_with_mapped_region(
+        self,
+        mock_count_valid,
+        mock_score_adaptive,
+        mock_is_user_ptr,
+        mock_read_u64,
+        mock_try_read,
+        mock_enumerate,
+    ):
         # Setup regions: one mapped region containing the pattern
         mock_enumerate.return_value = [
-            {"Base": 0x10000, "Size": 0x1000, "Protect": importer.PAGE_READWRITE, "Type": importer.MEM_MAPPED}
+            {
+                "Base": 0x10000,
+                "Size": 0x1000,
+                "Protect": importer.PAGE_READWRITE,
+                "Type": importer.MEM_MAPPED,
+            }
         ]
 
         layer_count = 100
@@ -100,13 +119,13 @@ class TestMockScanner(unittest.TestCase):
 
         chunk = bytearray(importer.CHUNK_SIZE)
         offset = 100
-        chunk[offset:offset+4] = pattern
+        chunk[offset : offset + 4] = pattern
 
         mock_try_read.side_effect = [
-            chunk, # scan_region_task
-            struct.pack("<Q", 0x3000), # read_u64(table_addr) inside the loop
+            chunk,  # scan_region_task
+            struct.pack("<Q", 0x3000),  # read_u64(table_addr) inside the loop
             # table_data for final pointers read
-            struct.pack("<100Q", *[0x4000+i for i in range(100)])
+            struct.pack("<100Q", *[0x4000 + i for i in range(100)]),
         ]
 
         mock_read_u64.return_value = 0x20000
@@ -116,6 +135,7 @@ class TestMockScanner(unittest.TestCase):
             if return_detail:
                 return (5, "")
             return 5
+
         mock_score_adaptive.side_effect = score_side_effect
 
         mock_count_valid.return_value = 100
@@ -124,10 +144,13 @@ class TestMockScanner(unittest.TestCase):
             mock_hm_inst = mock_hm.return_value
             mock_hm_inst.data = {"successful_regions": []}
 
-            pointers, group, table = importer.locate_layer_pointers(None, layer_count, 1000)
+            pointers, group, table = importer.locate_layer_pointers(
+                None, layer_count, 1000
+            )
 
             self.assertEqual(table, 0x20000)
             self.assertEqual(len(pointers), 100)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tools/fh6_import_layer_table.py
+++ b/tools/fh6_import_layer_table.py
@@ -19,6 +19,8 @@ PROCESS_QUERY_LIMITED_INFORMATION = 0x1000
 
 MEM_COMMIT = 0x1000
 MEM_PRIVATE = 0x20000
+MEM_MAPPED = 0x40000
+MEM_IMAGE = 0x1000000
 
 PAGE_NOACCESS = 0x01
 PAGE_READONLY = 0x02
@@ -275,7 +277,9 @@ def enumerate_regions(handle):
         if res == 0:
             break
 
-        if mbi.State == MEM_COMMIT and mbi.Type == MEM_PRIVATE:
+        # FH6 might store layer tables in MAPPED or IMAGE regions in some scenarios or versions
+        valid_types = (MEM_PRIVATE, MEM_MAPPED, MEM_IMAGE)
+        if mbi.State == MEM_COMMIT and (mbi.Type in valid_types):
             if is_readable(mbi.Protect) and is_writable(mbi.Protect):
                 regions.append(
                     {
@@ -335,10 +339,14 @@ class HeuristicsManager:
         self.save()
 
 
-def score_layer_adaptive(handle, layer_ptr, level=StrictnessLevel.PERFECT):
+def score_layer_adaptive(
+    handle, layer_ptr, level=StrictnessLevel.PERFECT, return_detail=False
+):
     if not is_user_ptr(layer_ptr):
-        return 0
+        return (0, "Invalid user pointer") if return_detail else 0
+
     score = 0
+    details = []
 
     pos = read_2_floats(handle, layer_ptr + LAYER_POS_OFFSET)
     coord_limit = 8192.0 if level == StrictnessLevel.PERFECT else 32768.0
@@ -348,6 +356,8 @@ def score_layer_adaptive(handle, layer_ptr, level=StrictnessLevel.PERFECT):
         and is_finite_in_range(pos[1], -coord_limit, coord_limit)
     ):
         score += 1
+    elif return_detail:
+        details.append(f"Pos invalid: {pos}")
 
     scale = read_2_floats(handle, layer_ptr + LAYER_SCALE_OFFSET)
     scale_limit = 64.0 if level == StrictnessLevel.PERFECT else 256.0
@@ -357,30 +367,44 @@ def score_layer_adaptive(handle, layer_ptr, level=StrictnessLevel.PERFECT):
         and is_finite_in_range(abs(scale[1]), 0.00001, scale_limit)
     ):
         score += 1
+    elif return_detail:
+        details.append(f"Scale invalid: {scale}")
 
     color = try_read(handle, layer_ptr + LAYER_COLOR_OFFSET, 4)
     if color is not None and len(color) == 4:
         score += 1
+    elif return_detail:
+        details.append("Color read failed")
 
     shape = try_read(handle, layer_ptr + LAYER_SHAPE_ID_OFFSET, 1)
     if shape is not None and len(shape) == 1:
         if level == StrictnessLevel.PERFECT:
             if shape[0] == SHAPE_ID_OTHER or shape[0] == SHAPE_ID_ELLIPSE:
                 score += 1
+            elif return_detail:
+                details.append(f"Shape ID mismatch: {shape[0]}")
         else:
             if shape[0] != 0:
                 score += 1
             else:
                 score += 1
+    elif return_detail:
+        details.append("Shape ID read failed")
 
     mask = try_read(handle, layer_ptr + LAYER_MASK_OFFSET, 1)
     if mask is not None and len(mask) == 1:
         if level == StrictnessLevel.PERFECT:
             if mask[0] == 0 or mask[0] == 1:
                 score += 1
+            elif return_detail:
+                details.append(f"Mask invalid: {mask[0]}")
         else:
             score += 1
+    elif return_detail:
+        details.append("Mask read failed")
 
+    if return_detail:
+        return score, "; ".join(details)
     return score
 
 
@@ -613,19 +637,30 @@ def locate_layer_pointers(handle, layer_count, max_candidates):
                     valid_ptrs = True
                     failure_detail = None
 
+                    type_name = "PRIVATE"
+                    if region["Type"] == MEM_MAPPED:
+                        type_name = "MAPPED"
+                    elif region["Type"] == MEM_IMAGE:
+                        type_name = "IMAGE"
+
                     for i in range(sample_len):
                         ptr = read_u64(handle, table_addr + i * 8)
                         if not is_user_ptr(ptr):
                             valid_ptrs = False
                             failure_detail = (
-                                f"圖層 {i} 指針 0x{ptr:X} 不是有效的用戶空間指針"
+                                f"[{type_name}] 圖層 {i} 指針 0x{ptr:X} 不是有效的用戶空間指針"
                             )
                             break
 
-                        sp = score_layer_adaptive(handle, ptr, StrictnessLevel.PERFECT)
+                        sp, det = score_layer_adaptive(
+                            handle, ptr, StrictnessLevel.PERFECT, return_detail=True
+                        )
                         sr = score_layer_adaptive(handle, ptr, StrictnessLevel.RELAXED)
                         sm = score_layer_adaptive(handle, ptr, StrictnessLevel.MINIMAL)
                         sample_scores.append((sp, sr, sm))
+
+                        if sp < 5 and not failure_detail:
+                            failure_detail = f"[{type_name}] 圖層 {i} 驗證失敗: {det}"
 
                     if not valid_ptrs or len(sample_scores) < sample_len:
                         is_p = is_r = is_m = False

--- a/tools/fh6_import_layer_table.py
+++ b/tools/fh6_import_layer_table.py
@@ -647,9 +647,7 @@ def locate_layer_pointers(handle, layer_count, max_candidates):
                         ptr = read_u64(handle, table_addr + i * 8)
                         if not is_user_ptr(ptr):
                             valid_ptrs = False
-                            failure_detail = (
-                                f"[{type_name}] 圖層 {i} 指針 0x{ptr:X} 不是有效的用戶空間指針"
-                            )
+                            failure_detail = f"[{type_name}] 圖層 {i} 指針 0x{ptr:X} 不是有效的用戶空間指針"
                             break
 
                         sp, det = score_layer_adaptive(


### PR DESCRIPTION
This change improves the memory scanning robustness by including MAPPED and IMAGE memory regions during the search for LiveryGroups. It also adds detailed diagnostic logging to the validation process, allowing users to see exactly why potential candidates were rejected (e.g., invalid coordinates or scale). The GUI error message was also updated with specific troubleshooting steps.

Fixes #10

---
*PR created automatically by Jules for task [13329061246921207736](https://jules.google.com/task/13329061246921207736) started by @eddie772tw*