### PR TITLE
Upgrade pytest test suite for better coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,4 @@ optimization_settings.json
 /nuitka_dist
 
 optimization_settings.json
+.coverage

--- a/tests/test_fh6_painter_generator.py
+++ b/tests/test_fh6_painter_generator.py
@@ -1,0 +1,63 @@
+import json
+import os
+import tempfile
+
+import numpy as np
+import pytest
+from PIL import Image
+
+
+def test_generator_boundary_weight_map():
+    from tools.fh6_painter_generator import get_boundary_weight_map
+
+    alpha_mask = np.zeros((10, 10), dtype=np.float32)
+    alpha_mask[2:8, 2:8] = 1.0
+
+    weight_map = get_boundary_weight_map(alpha_mask, 5.0)
+    assert weight_map.shape == (10, 10)
+    # The sum of weight_map should be > 0 due to boundaries
+    assert np.sum(weight_map) > 0.0
+
+
+def test_scale_shapes_list():
+    import copy
+
+    from tools.fh6_painter_generator import scale_shapes_list
+
+    shapes = [
+        {"type": 1, "data": [0.0, 0.0, 100.0, 100.0], "color": [255, 255, 255, 0]},
+        {"type": 32, "data": [10.0, 10.0, 5.0, 5.0, 0.0], "color": [255, 0, 0, 255]},
+    ]
+
+    # scale_shapes_list mutates in-place
+    shapes_copy = copy.deepcopy(shapes)
+    scale_shapes_list(shapes_copy, 2.0)
+
+    assert shapes_copy[0]["data"][2] == 200.0
+    assert shapes_copy[0]["data"][3] == 200.0
+
+    assert shapes_copy[1]["data"][0] == 20.0
+    assert shapes_copy[1]["data"][1] == 20.0
+    assert shapes_copy[1]["data"][2] == 10.0
+    assert shapes_copy[1]["data"][3] == 10.0
+
+
+def test_load_profile():
+    from tools.fh6_painter_generator import load_profile
+
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".ini", delete=False) as f:
+        f.write("[Settings]\n")
+        f.write("candidates = 500\n")
+        f.write("shapes = 1\n")
+        f.write("alpha = 128\n")
+        f.write("mutations = 10\n")
+        profile_path = f.name
+
+    try:
+        profile = load_profile(profile_path)
+        assert int(profile["candidates"]) == 500
+        assert int(profile["shapes"]) == 1
+        assert int(profile["alpha"]) == 128
+        assert int(profile["mutations"]) == 10
+    finally:
+        os.remove(profile_path)

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -273,7 +273,7 @@ def test_early_convergence_with_progressive_sampling(temp_image_path):
         },
         "image_pyramid": {
             "enabled": True,
-        }
+        },
     }
 
     try:

--- a/tests/test_go_opencl_evaluator.py
+++ b/tests/test_go_opencl_evaluator.py
@@ -1,0 +1,32 @@
+import numpy as np
+import pytest
+
+
+def test_go_opencl_evaluator_methods():
+    from evaluators.go_opencl_evaluator import GoOpenCLEvaluator
+
+    target = np.random.rand(16, 16, 3).astype(np.float32)
+    evaluator = GoOpenCLEvaluator(target)
+
+    # Test initialization
+    assert evaluator.get_name() == "Go OpenCL (GPU, Fastest)"
+    assert evaluator.get_device_type() == "GPU"
+    assert isinstance(evaluator.is_available(), bool)
+
+    # Check that NotImplementError is correctly raised for JIT interface
+    with pytest.raises(NotImplementedError):
+        evaluator.search_best_shape(target, 4, {})
+
+    with pytest.raises(NotImplementedError):
+        evaluator.draw_shape_on_canvas(
+            target, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0
+        )
+
+    # Check fallback implementations
+    canvas = np.zeros_like(target)
+    evaluator.rebuild_canvas(canvas, [], 0.0, 0.0, 0.0)
+
+    uncovered_map = evaluator.init_uncovered_map(16, 16, has_alpha=False, bias=0.1)
+    assert uncovered_map.shape == (16, 16)
+
+    evaluator.cleanup()

--- a/tests/test_launcher.py
+++ b/tests/test_launcher.py
@@ -1,0 +1,73 @@
+import json
+import os
+import tempfile
+
+import pytest
+
+from fh6_painter_launcher import (
+    build_save_at,
+    count_importable_shapes,
+    is_forza_painter_canvas_header,
+    is_json,
+    pick_template_layer_count,
+    replace_setting,
+)
+
+
+def test_is_json():
+    assert is_json("test.json") is True
+    assert is_json("TEST.JSON") is True
+    assert is_json("test.png") is False
+
+
+def test_is_forza_painter_canvas_header():
+    valid = {"type": 1, "data": [0.0, 0.0, 100, 100], "color": [255, 255, 255, 0]}
+    assert is_forza_painter_canvas_header(valid) is True
+
+    invalid_type = {
+        "type": 2,
+        "data": [0.0, 0.0, 100, 100],
+        "color": [255, 255, 255, 0],
+    }
+    assert is_forza_painter_canvas_header(invalid_type) is False
+
+    invalid_data = {
+        "type": 1,
+        "data": [1.0, 0.0, 100, 100],
+        "color": [255, 255, 255, 0],
+    }
+    assert is_forza_painter_canvas_header(invalid_data) is False
+
+
+def test_count_importable_shapes():
+    data = {
+        "shapes": [
+            {"type": 1, "data": [0.0, 0.0, 100, 100], "color": [255, 255, 255, 0]},
+            {"type": 32, "data": [10, 10, 5, 5, 0], "color": [255, 0, 0, 255]},
+            {"type": 32, "data": [20, 20, 5, 5, 0], "color": [0, 255, 0, 255]},
+        ]
+    }
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+        json.dump(data, f)
+        path = f.name
+
+    try:
+        assert count_importable_shapes(path) == 2
+        assert pick_template_layer_count(path) == 1500
+    finally:
+        os.remove(path)
+
+
+def test_build_save_at():
+    assert build_save_at(1500) == "500,1000,1500"
+    assert build_save_at(1200) == "500,1000,1200"
+
+
+def test_replace_setting():
+    text = "saveAt = 500\nstopAt = 1000"
+    res = replace_setting(text, "saveAt", "500,1000,1500")
+    assert "saveAt = 500,1000,1500" in res
+    assert "stopAt = 1000" in res
+
+    res = replace_setting(text, "newKey", "123")
+    assert "newKey = 123" in res

--- a/tests/test_taichi_evaluator.py
+++ b/tests/test_taichi_evaluator.py
@@ -1,0 +1,25 @@
+import numpy as np
+import pytest
+
+
+def test_taichi_evaluator_basic():
+    from evaluators.taichi_evaluator import TaichiEvaluator
+
+    target = np.random.rand(16, 16, 3).astype(np.float32)
+
+    try:
+        evaluator = TaichiEvaluator(target)
+    except Exception as e:
+        pytest.skip(f"Taichi initialization failed: {e}")
+
+    assert evaluator.get_device_type() == "GPU"
+    assert "Taichi JIT" in evaluator.get_name()
+    assert evaluator.is_available() is True
+
+    canvas = np.zeros_like(target)
+    evaluator.draw_shape_on_canvas(canvas, 8.0, 8.0, 4.0, 4.0, 0.0, 0.5, 0.5, 0.5, 1.0)
+
+    # Check if the drawn area has the correct color values
+    assert np.any(canvas[:, :, 0] > 0)
+
+    evaluator.cleanup()


### PR DESCRIPTION
This submission significantly improves test coverage across multiple parts of the application, including the launcher script, generator utilities, and the fallback behaviors of hardware-accelerated evaluators. It ensures that critical functions used in production scenarios are properly tested and verified. Additionally, it updates the `.gitignore` to prevent tracking `.coverage` files generated by `pytest-cov`.

---
*PR created automatically by Jules for task [3240179599638531153](https://jules.google.com/task/3240179599638531153) started by @eddie772tw*