### PR TITLE
Fix windnd AttributeError in GUI

### DIFF
--- a/gui/app.py
+++ b/gui/app.py
@@ -167,7 +167,10 @@ class ForzaStudioGUI(
         self.root.after(100, self.poll_background_updates)
 
         if windnd:
-            windnd.hook_drop(self.root, self.on_file_drop)
+            if hasattr(windnd, "hook_dropfiles"):
+                windnd.hook_dropfiles(self.root, func=self.on_file_drop)
+            elif hasattr(windnd, "hook_drop"):
+                windnd.hook_drop(self.root, self.on_file_drop)
 
         if preload_file:
             self.entry_file_path.insert(0, os.path.abspath(preload_file))


### PR DESCRIPTION
Fixes test failure due to missing `hook_drop` method in the `windnd` library.

The `gui/app.py` script was calling `windnd.hook_drop`, which is no longer correct or exposed as such in some environments (like the version installed here, which uses `hook_dropfiles`). This change uses `hasattr` to safely call whichever method the installed library actually exposes. This allows tests in `test_gui.py` to correctly bypass or load the module without crashing.

---
*PR created automatically by Jules for task [17361836145659533018](https://jules.google.com/task/17361836145659533018) started by @eddie772tw*