### PR TITLE
feat: Add Git branch and commit info to window title

### DIFF
--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -1,4 +1,26 @@
 // @ts-check
+/* global __GIT_BRANCH__, __GIT_COMMIT__ */
+
+// Dynamic Title based on Git Info
+if (typeof __GIT_BRANCH__ !== 'undefined' && typeof __GIT_COMMIT__ !== 'undefined') {
+  document.title = `FH6 Painter Studio - ${__GIT_BRANCH__} (${__GIT_COMMIT__})`;
+
+  // Also add it visually to the custom Tauri titlebar if present
+  document.addEventListener('DOMContentLoaded', () => {
+    const logoArea = document.querySelector('.logo-area');
+    if (logoArea) {
+      const gitBadge = document.createElement('span');
+      gitBadge.className = 'badge git-badge';
+      gitBadge.style.opacity = '0.7';
+      gitBadge.style.fontSize = '0.7em';
+      gitBadge.style.marginLeft = '8px';
+      gitBadge.style.backgroundColor = 'var(--bg-glass)';
+      gitBadge.style.border = '1px solid var(--glass-border)';
+      gitBadge.textContent = `${__GIT_BRANCH__} (${__GIT_COMMIT__})`;
+      logoArea.appendChild(gitBadge);
+    }
+  });
+}
 
 const wsUrl = "ws://localhost:8765";
 let ws = null;

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,8 +1,23 @@
 import { defineConfig } from "vite";
+import { execSync } from "child_process";
 
 const host = process.env.TAURI_DEV_HOST;
 
+let gitCommit = "unknown";
+let gitBranch = "unknown";
+
+try {
+  gitCommit = execSync("git rev-parse --short HEAD").toString().trim();
+  gitBranch = execSync("git rev-parse --abbrev-ref HEAD").toString().trim();
+} catch (e) {
+  console.warn("Could not retrieve git information.");
+}
+
 export default defineConfig({
+  define: {
+    __GIT_COMMIT__: JSON.stringify(gitCommit),
+    __GIT_BRANCH__: JSON.stringify(gitBranch),
+  },
   clearScreen: false,
   server: {
     port: 1420,


### PR DESCRIPTION
The feature modifies Vite configuration and frontend main scripts to display the active branch and commit hash in both standard window titles and custom Tauri titlebars.

---
*PR created automatically by Jules for task [2701550552440883452](https://jules.google.com/task/2701550552440883452) started by @eddie772tw*