### PR TITLE
Unswitch boolean flags in Taichi kernel

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -40,3 +40,11 @@
 ## 2026-07-15 - Numba 2D Boolean Mask Assignment
 **Learning:** In Numba JIT functions compiled in `nopython` mode, 2D boolean mask assignments (e.g., `arr[mask > threshold] = value`) fail to compile due to typing errors with setitem (`Multi-dimensional indices are not supported.`). While Numba supports 1D boolean masks, it cannot natively vectorize this pattern across multi-dimensional arrays without throwing `NumbaTypeError`.
 **Action:** When performing conditional updates against a multi-dimensional threshold map inside Numba JIT kernels (like `alpha_mask > 10.0`), use explicit nested 2D spatial loops to iterate over coordinates instead of boolean mask assignment arrays to prevent compilation failures.
+
+## 2026-07-20 - Loop unswitching in Taichi Evaluator for validation check
+**Learning:** The `check_contour` and `use_freeze` configuration flags in the inner `evaluate_candidate_ti` loop inside `taichi_evaluator.py` caused branching for every pixel checked. This prevented the LLVM/Taichi compiler from optimally executing the tight loop. Numba CPU already implemented unswitching for `use_freeze` externally, and `taichi_evaluator.py` was lagging in this optimization.
+**Action:** Unswitched the `check_contour` and `use_freeze` validations in the Taichi loop by hoisting these boolean checks outside of the pixel Y/X evaluation loops.
+
+## 2026-07-20 - Taichi GPU Loop Unswitching for Boolean Flags
+**Learning:** In the highly executed Taichi scanline evaluation kernel (`evaluate_candidate_ti`), configuration flags such as `check_contour` and `use_freeze` (in the validation pass) and `use_weight`/`use_uncovered` (in the accumulation pass) were checked inside the inner loops. This per-pixel branching causes thread divergence and inhibits Taichi/LLVM from adequately vectorizing or unswitching the loops automatically on the GPU. Numba kernels previously incorporated unswitching for `use_freeze` and others, but Taichi was lagging.
+**Action:** Unswitched these configuration checks by manually hoisting the `if` branches completely outside the spatial bounding box iteration loops, creating discrete code paths (fast/slow branches) for the inner core. While this duplicates loop structures in source code, it dramatically lowers branch overhead during runtime execution.

--- a/evaluators/taichi_evaluator.py
+++ b/evaluators/taichi_evaluator.py
@@ -130,7 +130,9 @@ def evaluate_candidate_ti(
         inv_a = 1.0 / a if a > 0.0 else 0.0
 
         # Validation Pass (Scalar constraints check)
-        if check_contour == 1 or use_freeze == 1:
+        # ⚡ Bolt Optimization: Loop unswitching for check_contour and use_freeze boolean flags.
+        # By pulling the configuration flag outside the inner pixel-loop, we remove per-pixel branching
+        if check_contour == 1 and use_freeze == 0:
             y = min_y
             while y <= max_y and is_valid == 1:
                 dy = ti.cast(y, ti.f32) - y_c
@@ -145,9 +147,47 @@ def evaluate_candidate_ti(
 
                     x = x_start
                     while x <= x_end and is_valid == 1:
-                        if check_contour == 1 and alpha_mask[y, x] <= 10.0:
+                        if alpha_mask[y, x] <= 10.0:
                             is_valid = 0
-                        if use_freeze == 1 and freeze_mask[y, x] == 1:
+                        x += sample_step
+                y += sample_step
+        elif check_contour == 0 and use_freeze == 1:
+            y = min_y
+            while y <= max_y and is_valid == 1:
+                dy = ti.cast(y, ti.f32) - y_c
+                b_val = dy * b_coeff
+                discriminant = a - dy * dy * inv_rx2_ry2
+                if discriminant >= 0.0:
+                    sqrt_d = ti.math.sqrt(discriminant)
+                    dx_min = (-b_val - sqrt_d) * inv_a
+                    dx_max = (-b_val + sqrt_d) * inv_a
+                    x_start = ti.max(min_x, ti.cast(ti.math.ceil(x_c + dx_min), ti.i32))
+                    x_end = ti.min(max_x, ti.cast(ti.math.floor(x_c + dx_max), ti.i32))
+
+                    x = x_start
+                    while x <= x_end and is_valid == 1:
+                        if freeze_mask[y, x] == 1:
+                            is_valid = 0
+                        x += sample_step
+                y += sample_step
+        elif check_contour == 1 and use_freeze == 1:
+            y = min_y
+            while y <= max_y and is_valid == 1:
+                dy = ti.cast(y, ti.f32) - y_c
+                b_val = dy * b_coeff
+                discriminant = a - dy * dy * inv_rx2_ry2
+                if discriminant >= 0.0:
+                    sqrt_d = ti.math.sqrt(discriminant)
+                    dx_min = (-b_val - sqrt_d) * inv_a
+                    dx_max = (-b_val + sqrt_d) * inv_a
+                    x_start = ti.max(min_x, ti.cast(ti.math.ceil(x_c + dx_min), ti.i32))
+                    x_end = ti.min(max_x, ti.cast(ti.math.floor(x_c + dx_max), ti.i32))
+
+                    x = x_start
+                    while x <= x_end and is_valid == 1:
+                        if alpha_mask[y, x] <= 10.0:
+                            is_valid = 0
+                        if freeze_mask[y, x] == 1:
                             is_valid = 0
                         x += sample_step
                 y += sample_step
@@ -199,6 +239,110 @@ def evaluate_candidate_ti(
                             sum_ct_b += c_b * t_b
                             x += sample_step
                     y += sample_step
+            elif use_weight == 1 and use_uncovered == 0:
+                y = min_y
+                while y <= max_y:
+                    dy = ti.cast(y, ti.f32) - y_c
+                    b_val = dy * b_coeff
+                    discriminant = a - dy * dy * inv_rx2_ry2
+                    if discriminant >= 0.0:
+                        sqrt_d = ti.math.sqrt(discriminant)
+                        dx_min = (-b_val - sqrt_d) * inv_a
+                        dx_max = (-b_val + sqrt_d) * inv_a
+                        x_start = ti.max(
+                            min_x, ti.cast(ti.math.ceil(x_c + dx_min), ti.i32)
+                        )
+                        x_end = ti.min(
+                            max_x, ti.cast(ti.math.floor(x_c + dx_max), ti.i32)
+                        )
+
+                        x = x_start
+                        while x <= x_end:
+                            t_r = target_r[y, x]
+                            t_g = target_g[y, x]
+                            t_b = target_b[y, x]
+
+                            c_r = canvas_r[y, x]
+                            c_g = canvas_g[y, x]
+                            c_b = canvas_b[y, x]
+
+                            w = weight_map[y, x]
+
+                            count += w
+                            sum_t_r += t_r * w
+                            sum_t_g += t_g * w
+                            sum_t_b += t_b * w
+
+                            # ⚡ Bolt Optimization: Factorize c_r * w to prevent redundant multiplications
+                            c_r_w = c_r * w
+                            c_g_w = c_g * w
+                            c_b_w = c_b * w
+
+                            sum_c_r += c_r_w
+                            sum_c_g += c_g_w
+                            sum_c_b += c_b_w
+
+                            sum_c2_r += c_r * c_r_w
+                            sum_c2_g += c_g * c_g_w
+                            sum_c2_b += c_b * c_b_w
+
+                            sum_ct_r += t_r * c_r_w
+                            sum_ct_g += t_g * c_g_w
+                            sum_ct_b += t_b * c_b_w
+                            x += sample_step
+                    y += sample_step
+            elif use_weight == 0 and use_uncovered == 1:
+                y = min_y
+                while y <= max_y:
+                    dy = ti.cast(y, ti.f32) - y_c
+                    b_val = dy * b_coeff
+                    discriminant = a - dy * dy * inv_rx2_ry2
+                    if discriminant >= 0.0:
+                        sqrt_d = ti.math.sqrt(discriminant)
+                        dx_min = (-b_val - sqrt_d) * inv_a
+                        dx_max = (-b_val + sqrt_d) * inv_a
+                        x_start = ti.max(
+                            min_x, ti.cast(ti.math.ceil(x_c + dx_min), ti.i32)
+                        )
+                        x_end = ti.min(
+                            max_x, ti.cast(ti.math.floor(x_c + dx_max), ti.i32)
+                        )
+
+                        x = x_start
+                        while x <= x_end:
+                            t_r = target_r[y, x]
+                            t_g = target_g[y, x]
+                            t_b = target_b[y, x]
+
+                            c_r = canvas_r[y, x]
+                            c_g = canvas_g[y, x]
+                            c_b = canvas_b[y, x]
+
+                            w = uncovered_map[y, x]
+
+                            count += w
+                            sum_t_r += t_r * w
+                            sum_t_g += t_g * w
+                            sum_t_b += t_b * w
+
+                            # ⚡ Bolt Optimization: Factorize c_r * w to prevent redundant multiplications
+                            c_r_w = c_r * w
+                            c_g_w = c_g * w
+                            c_b_w = c_b * w
+
+                            sum_c_r += c_r_w
+                            sum_c_g += c_g_w
+                            sum_c_b += c_b_w
+
+                            sum_c2_r += c_r * c_r_w
+                            sum_c2_g += c_g * c_g_w
+                            sum_c2_b += c_b * c_b_w
+
+                            sum_ct_r += t_r * c_r_w
+                            sum_ct_g += t_g * c_g_w
+                            sum_ct_b += t_b * c_b_w
+                            x += sample_step
+                    y += sample_step
             else:
                 y = min_y
                 while y <= max_y:
@@ -226,11 +370,7 @@ def evaluate_candidate_ti(
                             c_g = canvas_g[y, x]
                             c_b = canvas_b[y, x]
 
-                            w = 1.0
-                            if use_weight == 1:
-                                w = weight_map[y, x]
-                            if use_uncovered == 1:
-                                w = w * uncovered_map[y, x]
+                            w = weight_map[y, x] * uncovered_map[y, x]
 
                             count += w
                             sum_t_r += t_r * w


### PR DESCRIPTION
opt: Unswitch boolean flags in Taichi kernel

💡 What: Unswitched the `check_contour`, `use_freeze`, `use_weight`, and `use_uncovered` configuration flags in the inner `evaluate_candidate_ti` loop inside `taichi_evaluator.py` by hoisting the conditional checks outside of the spatial pixel evaluation loops. Also implemented `c_r * w` multiplication factorization to reduce per-pixel math operations.
🎯 Why: Having boolean branch conditions in the tightest inner loop evaluates millions of times per kernel execution, which causes thread divergence and inhibits Taichi's ability to vectorize and optimize the execution cleanly on the GPU.
📊 Impact: Considerably faster evaluation latency and lower core workload per ellipse candidate on GPU backends by stripping conditional complexity entirely out of the innermost loops.
🔬 Measurement: Verify using `pytest tests/test_taichi_evaluator.py` and local Taichi execution telemetry metrics when processing with weight maps or freeze masks.

---
*PR created automatically by Jules for task [4326857040829896297](https://jules.google.com/task/4326857040829896297) started by @eddie772tw*