### PR TITLE
docs: update README.md and frontend/README.md for accuracy

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ The project supports a fully dynamic multi-language framework. Contributors can 
      - [ ] 翻譯 JSON 中的所有翻譯鍵（Keys）皆已完整對齊 `en-us.json`
      - [ ] 確認翻譯內容中無殘留的中文字元或錯位
      - [ ] 已在本地測試過，選單能正常加載並正確切換該語系
-     - [ ] 已在本地手動執行並通過 i18n 單元測試 (Run and passed: `pytest tests/test_i18n.py`)
+     - [ ] 已在本地手動執行並通過 i18n 單元測試 (Run and passed: `PYTHONPATH=. pytest tests/test_i18n.py`)
      ```
 
 ---

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -10,7 +10,7 @@ This is the Tauri and Vanilla HTML/CSS/JS frontend for FH6-Painter. It provides 
 
 ## Development
 
-Make sure you have Node.js and Rust installed.
+Make sure you have Node.js installed to run the development server, and optionally Rust (cargo) if you wish to compile the native Tauri desktop application.
 
 ### Setup and Build
 


### PR DESCRIPTION
This PR updates the repository documentation to accurately reflect current dependencies and testing instructions.

### Changes
1. **`README.md`**: Fixed the translation PR checklist test command from `` `pytest tests/test_i18n.py` `` to `` `PYTHONPATH=. pytest tests/test_i18n.py` `` to ensure local test execution resolves imports correctly without raising `ModuleNotFoundError`.
2. **`frontend/README.md`**: Clarified that Rust (cargo) is an optional dependency solely for compiling the native Tauri desktop app, and that Node.js is only needed to run the frontend development server.

---
*PR created automatically by Jules for task [3310298278163822889](https://jules.google.com/task/3310298278163822889) started by @eddie772tw*